### PR TITLE
Feature/Student management

### DIFF
--- a/app/assets/javascripts/admins.coffee
+++ b/app/assets/javascripts/admins.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/diploma.coffee
+++ b/app/assets/javascripts/diploma.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/serapoke.coffee
+++ b/app/assets/javascripts/serapoke.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/staff_blogs.coffee
+++ b/app/assets/javascripts/staff_blogs.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/start_schedules.coffee
+++ b/app/assets/javascripts/start_schedules.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/students.coffee
+++ b/app/assets/javascripts/students.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/admins.scss
+++ b/app/assets/stylesheets/admins.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the admins controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,6 +20,10 @@
   max-width: 576px;
 }
 
+.mw-xl {
+  max-width: 1200px;
+}
+
 // 「ログインしました」などのフラッシュ用スタイル
 
 .alert-notice {

--- a/app/assets/stylesheets/diploma.scss
+++ b/app/assets/stylesheets/diploma.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Diploma controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/serapoke.scss
+++ b/app/assets/stylesheets/serapoke.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Serapoke controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/staff_blogs.scss
+++ b/app/assets/stylesheets/staff_blogs.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the StaffBlogs controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/start_schedules.scss
+++ b/app/assets/stylesheets/start_schedules.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the StartSchedules controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/students.scss
+++ b/app/assets/stylesheets/students.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Students controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -1,4 +1,16 @@
 class AdminsController < ApplicationController
+  # オブジェクトの準備
+  before_action :set_student, only: [:student_edit]
+  # アクセス制限↲
+  before_action :admin_only, only: [:student_edit]
+
   def student_edit
   end
+
+  private
+
+    def set_student
+      @student = Student.find(params[:student_id])
+    end
+
 end

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -1,0 +1,4 @@
+class AdminsController < ApplicationController
+  def student_edit
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,4 +29,13 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  private
+
+    def admin_only
+      unless current_staff.present? && current_staff.admin == true
+        flash[:danger] = "管理者しか受講生管理は出来ません。"
+        redirect_to root_path
+      end
+    end
+
 end

--- a/app/controllers/diploma_controller.rb
+++ b/app/controllers/diploma_controller.rb
@@ -1,0 +1,4 @@
+class DiplomaController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/serapoke_controller.rb
+++ b/app/controllers/serapoke_controller.rb
@@ -1,0 +1,4 @@
+class SerapokeController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/staff_blogs_controller.rb
+++ b/app/controllers/staff_blogs_controller.rb
@@ -1,0 +1,4 @@
+class StaffBlogsController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/start_schedules_controller.rb
+++ b/app/controllers/start_schedules_controller.rb
@@ -1,0 +1,4 @@
+class StartSchedulesController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -1,0 +1,5 @@
+class StudentsController < ApplicationController
+  def index
+    @students = Student.all
+  end
+end

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -1,5 +1,37 @@
 class StudentsController < ApplicationController
+  # オブジェクトの準備
+  before_action :set_student, only: [:show, :update, :destroy]
+  # アクセス制限
+  before_action :admin_only, only: [:index, :show, :update, :destroy]
+
   def index
     @students = Student.all
   end
+
+  def update
+    if @student.update_attributes(student_params)
+      flash[:success] = "受講生情報を更新しました。"
+      redirect_to @student
+    else
+      render :template=> "admins/student_edit", :locals=> { :@student=> @student }
+   end
+  end
+
+  def destroy
+    @student.destroy
+    flash[:success] = "「#{@student.name}」のデータを削除しました。"
+    redirect_to students_url
+  end
+
+  private
+
+    def set_student
+      @student = Student.find(params[:id])
+    end
+
+
+    def student_params
+      params.require(:student).permit(:name, :email, :course_type, :phone_nubmer)
+    end
+
 end

--- a/app/helpers/admins_helper.rb
+++ b/app/helpers/admins_helper.rb
@@ -1,0 +1,2 @@
+module AdminsHelper
+end

--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -16,4 +16,8 @@ module DeviseHelper
     end
     html.html_safe
   end
+
+  def devise_error_messages?
+    resource.errors.empty? ? false : true
+  end
 end

--- a/app/helpers/diploma_helper.rb
+++ b/app/helpers/diploma_helper.rb
@@ -1,0 +1,2 @@
+module DiplomaHelper
+end

--- a/app/helpers/serapoke_helper.rb
+++ b/app/helpers/serapoke_helper.rb
@@ -1,0 +1,2 @@
+module SerapokeHelper
+end

--- a/app/helpers/staff_blogs_helper.rb
+++ b/app/helpers/staff_blogs_helper.rb
@@ -1,0 +1,2 @@
+module StaffBlogsHelper
+end

--- a/app/helpers/start_schedules_helper.rb
+++ b/app/helpers/start_schedules_helper.rb
@@ -1,0 +1,2 @@
+module StartSchedulesHelper
+end

--- a/app/helpers/students_helper.rb
+++ b/app/helpers/students_helper.rb
@@ -1,0 +1,2 @@
+module StudentsHelper
+end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -3,4 +3,8 @@ class Student < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  validates :name, presence: true, length: { minimum: 2 }
+  validates :email, presence: true, length: { maximum: 100 }, uniqueness: true
+  validates :course_type, inclusion: { in: ["therapist_training","self_care"] }
 end

--- a/app/views/admin_screen/index.html.erb
+++ b/app/views/admin_screen/index.html.erb
@@ -8,7 +8,7 @@
     <%= link_to '開講スケジュール投稿', start_schedules_path %>
   </li>
   <li class="list-group-item">
-    <%= link_to 'ユーザー管理', students_path %>
+    <%= link_to '受講生管理', students_path %>
   </li>
   <li class="list-group-item">
     <%= link_to 'せらポケ管理', serapoke_path %>

--- a/app/views/admin_screen/index.html.erb
+++ b/app/views/admin_screen/index.html.erb
@@ -2,17 +2,18 @@
 
 <ul class="list-group-flush">
   <li class="list-group-item">
-    <%= link_to 'スタッフブログ投稿', "#" %>
+    <%= link_to 'スタッフブログ投稿', staff_blogs_path %>
   </li>
   <li class="list-group-item">
-    <%= link_to '開講スケジュール投稿', "#" %>
+    <%= link_to '開講スケジュール投稿', start_schedules_path %>
   </li>
   <li class="list-group-item">
-    <%= link_to 'ユーザー管理', "#" %>
-  <li class="list-group-item">
-    <%= link_to 'せらポケ管理', "#" %>
+    <%= link_to 'ユーザー管理', students_path %>
   </li>
   <li class="list-group-item">
-    <%= link_to 'ディプロマ作成', "#" %>
+    <%= link_to 'せらポケ管理', serapoke_path %>
+  </li>
+  <li class="list-group-item">
+    <%= link_to 'ディプロマ作成', diploma_path %>
   </li>
 </ul>

--- a/app/views/admins/_form.html.erb
+++ b/app/views/admins/_form.html.erb
@@ -1,0 +1,18 @@
+<%= form_with(model: @student, local: true) do |f| %>
+  <!--%= render 'shared/error_messages_student', object: @student %-->
+  <%= render 'devise/shared/error_messages', resource: @student %>
+
+  <%= f.label :name, class: "label-#{yield(:class_text)}" %>
+  <%= f.text_field :name, class: "form-control" %>
+
+  <%= f.label :email, class: "label-#{yield(:class_text)}" %>
+  <%= f.email_field :email, class: "form-control" %>
+
+  <%= f.label :course_type, class: "label-#{yield(:class_text)}" %>
+  <%= f.text_field :course_type, class: "form-control" %>
+
+  <%= f.label :phone_number, class: "label-#{yield(:class_text)}" %>
+  <%= f.text_field :phone_number, class: "form-control" %>
+
+  <%= f.submit yield(:button_text), class: "btn btn-primary btn-block btn-#{yield(:class_text)}" %>
+<% end %>

--- a/app/views/admins/student_edit.html.erb
+++ b/app/views/admins/student_edit.html.erb
@@ -1,0 +1,2 @@
+<h1>Admins#student_edit</h1>
+<p>Find me in app/views/admins/student_edit.html.erb</p>

--- a/app/views/admins/student_edit.html.erb
+++ b/app/views/admins/student_edit.html.erb
@@ -1,2 +1,9 @@
-<h1>Admins#student_edit</h1>
-<p>Find me in app/views/admins/student_edit.html.erb</p>
+<% provide(:class_text, 'student--edit') %>
+<% provide(:button_text, '編集') %>
+<h1>アカウント情報の更新</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= render 'admins/form' %>
+  </div>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -30,5 +30,9 @@
   <%= link_to '管理者・スタッフはこちら', new_staff_session_path %>
 <% end %>
 
+<% if resource_name == :staff %>
+  <%= link_to '受講生はこちら', new_student_session_path %>
+<% end %>
+
 <!--%= render 'devise/shared/links' %-->
 

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,0 +1,18 @@
+<% if resource.errors.any? %>
+  <div id="error_explanation">
+    <div class="alert alert-danger">
+      <h2>
+        <%= I18n.t("errors.messages.not_saved",
+                   count: resource.errors.count,
+                   resource: resource.class.model_name.human.downcase)
+        %>
+      </h2>
+      <ul>
+        <% resource.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+<% end %>
+

--- a/app/views/diploma/index.html.erb
+++ b/app/views/diploma/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Diploma#index</h1>
+<p>Find me in app/views/diploma/index.html.erb</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
 
   <body>
     <%= render 'layouts/header' %>
-    <div class="container-fluid py-4 mw-md">
+    <div class="container-fluid py-4 <%= devise_controller? ? 'mw-md' : 'mw-xl' %>">
       <%= yield %>
     </div>
     <%= debug(params) if Rails.env.development? %>

--- a/app/views/serapoke/index.html.erb
+++ b/app/views/serapoke/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Serapoke#index</h1>
+<p>Find me in app/views/serapoke/index.html.erb</p>

--- a/app/views/staff_blogs/index.html.erb
+++ b/app/views/staff_blogs/index.html.erb
@@ -1,0 +1,2 @@
+<h1>StaffBlogs#index</h1>
+<p>Find me in app/views/staff_blogs/index.html.erb</p>

--- a/app/views/staffs_screen/index.html.erb
+++ b/app/views/staffs_screen/index.html.erb
@@ -2,9 +2,9 @@
 
 <ul class="list-group-flush">
   <li class="list-group-item">
-    <%= link_to 'スタッフブログ投稿', "#" %>
+    <%= link_to 'スタッフブログ投稿', staff_blogs_path %>
   </li>
   <li class="list-group-item">
-    <%= link_to '開講スケジュール投稿', "#" %>
+    <%= link_to '開講スケジュール投稿', start_schedules_path %>
   </li>
 </ul>

--- a/app/views/start_schedules/index.html.erb
+++ b/app/views/start_schedules/index.html.erb
@@ -1,0 +1,2 @@
+<h1>StartSchedules#index</h1>
+<p>Find me in app/views/start_schedules/index.html.erb</p>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,2 +1,3 @@
 <h1>EarTherageトップページ</h1>
+<%= render 'layouts/flash_messages' %>
 <%= link_to "受講生の方はこちら", new_student_session_path, class: 'nav-link' %>

--- a/app/views/students/index.html.erb
+++ b/app/views/students/index.html.erb
@@ -1,0 +1,61 @@
+<h1>受講生一覧</h1>
+<div class="container">
+  <div class="row">
+    <div class="col-1">
+      ID
+    </div>
+    <div class="col-2">
+      名前
+    </div>
+    <div class="col-3">
+      Eメール
+    </div>
+    <div class="col-2">
+      コース
+    </div>
+    <div class="col-2">
+      電話番号
+    </div>
+    <% if current_staff.present? %>
+      <div class="col-1">
+      </div>
+      <div class="col-1">
+      </div>
+    <% end %>
+  </div>
+  <% @students.each do |student| %>
+    <div class="row justify-content-md-center">
+      <div class="col-1">
+        <%= student.id %>
+      </div>
+      <% if current_staff.present? %>
+        <div class="col-2">
+          <%= link_to student.name, student_edit_admin_path(student_id: student.id) %>
+        </div>
+      <% else %>
+          <div class="col-2">
+            <%= student.name %>
+          </div>
+      <% end %>
+      <div class="col-3">
+        <%= student.email %>
+      </div>
+      <div class="col-2">
+        <%= student.course_type %>
+      </div>
+      <div class="col-2">
+        <%= student.phone_number %>
+      </div>
+      <% if current_staff.present? %>
+        <div class="col-1">
+          <%= link_to "削除", student, method: :delete,
+              data: { confirm: "削除してよろしいですか？" },
+              class: "btn btn-danger" %>
+        </div>
+        <div class="col-1">
+          <%= link_to "詳細", student_path(student) %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/students/index.html.erb
+++ b/app/views/students/index.html.erb
@@ -1,4 +1,5 @@
 <h1>受講生一覧</h1>
+<%= render 'layouts/flash_messages' %>
 <div class="container">
   <div class="row">
     <div class="col-1">

--- a/app/views/students/show.html.erb
+++ b/app/views/students/show.html.erb
@@ -1,0 +1,46 @@
+<h1>受講生詳細</h1>
+<%= render 'layouts/flash_messages' %>
+<div class="container">
+  <div class="row">
+    <div class="border col-3">
+      ID:
+    </div>
+    <div class="border-top border-right border-bottom col-6">
+      <%= @student.id %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="border-left border-right border-bottom col-3">
+      名前:
+    </div>
+    <div class="border-right border-bottom col-6">
+      <%= @student.name %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="border-left border-right border-bottom col-3">
+      Eメール:
+    </div>
+    <div class ="border-right border-bottom col-6">
+      <%= @student.email %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="border-left border-right border-bottom col-3">
+      電話番号:
+    </div>
+    <div class="border-right border-left border-bottom col-6">
+      <%= @student.phone_number %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="border-left border-right border-bottom col-3">
+      コース:
+    </div>
+    <div class="border-right border-bottom col-6">
+      <%= @student.course_type %>
+    </div>
+  </div>
+</div>
+<br>
+<%= link_to "戻る", students_path %>

--- a/config/locales/models/models_ja.yml
+++ b/config/locales/models/models_ja.yml
@@ -2,8 +2,25 @@ ja:
   activerecord:
     models:
       schedule: スケジュール
+      student: 受講生
+      staff: スタッフ
     attributes:
         schedule:
-
           created_at: 作成日
           updated_at: 更新日
+        student:
+          id: ID
+          name: 名前
+          email: Eメール
+          course_type: コース
+          phone_number: 電話番号
+          created_at: 作成日
+          updated_at: 更新日
+        staff:
+          id: ID
+          name: 名前
+          email: Eメール
+          admin: 管理者
+          created_at: 作成日
+          updated_at: 更新日
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,10 +7,22 @@ Rails.application.routes.draw do
   }
   root 'static_pages#top'
 
-  get 'therapist_training_course' => "therapist_training_course#index", as: :therapist_training_course#セラピスト養成コース画面
+  get 'therapist_training_course' => 'therapist_training_course#index', as: :therapist_training_course#セラピスト養成コース画面
   get 'self_care_course' => "self_care_course#index", as: :self_care_course#セルフケアコース画面
 
-  get 'admin_screen' => "admin_screen#index", as: :admin_screen#管理者画面
-  get 'staffs_screen' => "staffs_screen#index", as: :staffs_screen#スタッフ画面
+  get 'admin_screen' => 'admin_screen#index', as: :admin_screen#管理者画面
+  get 'staffs_screen' => 'staffs_screen#index', as: :staffs_screen#スタッフ画面
+
+  resources :staff_blogs#スタッフブログ
+
+  resources :start_schedules#開講スケジュール
+
+  resources :students#ユーザー管理
+
+  get 'serapoke' => 'serapoke#index', as: :serapoke#せらポケ
+
+  get 'diploma' => 'diploma#index', as: :diploma#ディプロマ
+
+  get '/admin/:student_id/student_edit' => 'admins#student_edit', as: :student_edit_admin
 
 end

--- a/test/controllers/admins_controller_test.rb
+++ b/test/controllers/admins_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class AdminsControllerTest < ActionDispatch::IntegrationTest
+  test "should get student_edit" do
+    get admins_student_edit_url
+    assert_response :success
+  end
+
+end

--- a/test/controllers/diploma_controller_test.rb
+++ b/test/controllers/diploma_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class DiplomaControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get diploma_index_url
+    assert_response :success
+  end
+
+end

--- a/test/controllers/serapoke_controller_test.rb
+++ b/test/controllers/serapoke_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class SerapokeControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get serapoke_index_url
+    assert_response :success
+  end
+
+end

--- a/test/controllers/staff_blogs_controller_test.rb
+++ b/test/controllers/staff_blogs_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class StaffBlogsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get staff_blogs_index_url
+    assert_response :success
+  end
+
+end

--- a/test/controllers/start_schedules_controller_test.rb
+++ b/test/controllers/start_schedules_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class StartSchedulesControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get start_schedules_index_url
+    assert_response :success
+  end
+
+end

--- a/test/controllers/students_controller_test.rb
+++ b/test/controllers/students_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class StudentsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get students_index_url
+    assert_response :success
+  end
+
+end


### PR DESCRIPTION
・やったこと
　管理者画面、スタッフ画面からリンク先を設定して、タイトルだけのページを開く。devise関連ページ以外のときに表示領域を広げる。student管理ページで編集、削除、詳細表示機能を実装。管理者だけstudent管理機能を実行できるようにする。管理者・スタッフログインページの下に受講生はこちらリンクを作成。
・まだやっていないこと
　csvファイル読み込み機能。スマホ対応。
・動作確認
管理者、スタッフ画面からリンク先をクリックして各ページを開くこと。student一覧表示画面で表示領域が広がっていること。student管理ページで編集、削除、詳細表示が機能していること。管理者以外で、urlからstudent一覧表示、編集、詳細表示にアクセスすると警告のflashメッセージが表示されてroot pageにリダイレクトされること。