### PR TITLE
Feature/Logged in constraint

### DIFF
--- a/app/constraints/logged_in_constraint.rb
+++ b/app/constraints/logged_in_constraint.rb
@@ -1,0 +1,5 @@
+class LoggedInConstraint < Struct.new(:value)
+  def matches?(request)
+    request.session.key?('current_user_id') == value
+  end
+end

--- a/app/constraints/logged_in_constraint.rb
+++ b/app/constraints/logged_in_constraint.rb
@@ -1,5 +1,5 @@
 class LoggedInConstraint < Struct.new(:value)
   def matches?(request)
-    request.session['student_id'] == value || request.session['student_id'].nil?
+    request.session[:student_id] == value || request.session[:student_id].nil?
   end
 end

--- a/app/constraints/logged_in_constraint.rb
+++ b/app/constraints/logged_in_constraint.rb
@@ -1,5 +1,5 @@
 class LoggedInConstraint < Struct.new(:value)
   def matches?(request)
-    request.session.key?('current_user_id') == value
+    request.session['student_id'] == value || request.session['student_id'].nil?
   end
 end

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -4,7 +4,7 @@ class BlogsController < ApplicationController
   before_action :set_staff, only: [:new, :create, :show]
   before_action :set_staff_by_blog_object, only: [:edit, :update, :destroy]
   # アクセス制限
-  before_action :correct_staff_only, only: [:edit, :update, :destroy]
+  before_action :correct_staff_only, only: [:new, :create, :edit, :update, :destroy]
 
   def index
     if current_staff.present?
@@ -87,7 +87,7 @@ class BlogsController < ApplicationController
     # 管理者かログインしているスタッフが自身のブログである場合のみアクセス可
     def correct_staff_only
       unless current_staff.present? && (current_staff.admin == true || current_staff.id == @staff.id)
-        flash[:notice] = "許可されていない操作でです。"
+        flash[:notice] = "許可されていない操作です。"
         redirect_to root_url
       end
     end

--- a/app/controllers/staffs/sessions_controller.rb
+++ b/app/controllers/staffs/sessions_controller.rb
@@ -13,8 +13,10 @@ class Staffs::SessionsController < Devise::SessionsController
         sign_in(resource_name, resource)
         yield resource if block_given?
         if self.resource.admin == false
+          session[:student_id] = "false"
           respond_with resource, :location => staff_after_sign_in_path_for(resource)
         elsif self.resource.admin == true
+          session[:student_id] = "true"
           respond_with resource, :location => admin_after_sign_in_path_for(resource)
         end
       else

--- a/app/controllers/students/sessions_controller.rb
+++ b/app/controllers/students/sessions_controller.rb
@@ -17,6 +17,7 @@ class Students::SessionsController < Devise::SessionsController
         elsif self.resource.course_type == "self_care"
           respond_with resource, :location => self_care_course_student_after_sign_in_path_for(resource)
         end
+        session[:student_id] = self.resource.course_type
       else
         flash[:danger] = "Eメールが違います"
         redirect_to new_student_session_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,11 @@
 Rails.application.routes.draw do
   #rootを受講生ログイン画面に設定
   devise_scope :student do
-    root 'therapist_training_course#index', as: :public_root, constraints: LoggedInConstraint.new(false)
-    root "students/sessions#new", constraints: LoggedInConstraint.new(true)
+    root 'therapist_training_course#index', as: :public_root, constraints: LoggedInConstraint.new("therapist_training")
+    root 'self_care_course#index', constraints: LoggedInConstraint.new("self_care")
+    root 'admin_screen#index', constraints: LoggedInConstraint.new("true")
+    root 'staffs_screen#index', constraints: LoggedInConstraint.new("false")
+    root "students/sessions#new", constraints: LoggedInConstraint.new("")
   end
 
   devise_for :staffs, :controllers => {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,8 @@
 Rails.application.routes.draw do
   #rootを受講生ログイン画面に設定
   devise_scope :student do
-    constraints ->  request { request.session[:student_id].present? } do
-      root to: 'therapist_training_course#index'
-    end
-    root "students/sessions#new"
+    root 'therapist_training_course#index', as: :public_root, constraints: LoggedInConstraint.new(false)
+    root "students/sessions#new", constraints: LoggedInConstraint.new(true)
   end
 
   devise_for :staffs, :controllers => {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   #rootを受講生ログイン画面に設定
   devise_scope :student do
+    constraints ->  request { request.session[:student_id].present? } do
+      root to: 'therapist_training_course#index'
+    end
     root "students/sessions#new"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,7 +14,7 @@ ActiveRecord::Schema.define(version: 2021_06_15_130226) do
 
   create_table "blogs", force: :cascade do |t|
     t.string "title", default: "", null: false
-    t.datetime "datetime", default: "2021-06-29 14:26:42", null: false
+    t.datetime "datetime", default: "2021-07-01 12:54:52", null: false
     t.text "content", limit: 10485760
     t.string "image"
     t.integer "share_with", default: 0, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,7 +14,7 @@ ActiveRecord::Schema.define(version: 2021_06_15_130226) do
 
   create_table "blogs", force: :cascade do |t|
     t.string "title", default: "", null: false
-    t.datetime "datetime", default: "2021-06-26 11:14:00", null: false
+    t.datetime "datetime", default: "2021-06-26 13:19:17", null: false
     t.text "content", limit: 10485760
     t.string "image"
     t.integer "share_with", default: 0, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,7 +14,7 @@ ActiveRecord::Schema.define(version: 2021_06_15_130226) do
 
   create_table "blogs", force: :cascade do |t|
     t.string "title", default: "", null: false
-    t.datetime "datetime", default: "2021-06-26 13:19:17", null: false
+    t.datetime "datetime", default: "2021-06-27 14:40:58", null: false
     t.text "content", limit: 10485760
     t.string "image"
     t.integer "share_with", default: 0, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,7 +14,7 @@ ActiveRecord::Schema.define(version: 2021_06_15_130226) do
 
   create_table "blogs", force: :cascade do |t|
     t.string "title", default: "", null: false
-    t.datetime "datetime", default: "2021-06-28 14:35:06", null: false
+    t.datetime "datetime", default: "2021-06-29 14:26:42", null: false
     t.text "content", limit: 10485760
     t.string "image"
     t.integer "share_with", default: 0, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,7 +14,7 @@ ActiveRecord::Schema.define(version: 2021_06_15_130226) do
 
   create_table "blogs", force: :cascade do |t|
     t.string "title", default: "", null: false
-    t.datetime "datetime", default: "2021-06-27 14:40:58", null: false
+    t.datetime "datetime", default: "2021-06-28 14:35:06", null: false
     t.text "content", limit: 10485760
     t.string "image"
     t.integer "share_with", default: 0, null: false

--- a/spec/controllers/admins_controller_spec.rb
+++ b/spec/controllers/admins_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe AdminsController, type: :controller do
-  describe "#index" do
+  describe "#student_edit" do
     context "正常系" do
       context "管理者としてログインしたとき" do
         context "as admin" do
@@ -19,6 +19,111 @@ RSpec.describe AdminsController, type: :controller do
           context "200レスポンスを返すこと" do
             it "returns a 200 response" do
               expect(response).to have_http_status "200"
+            end
+          end
+        end
+      end
+    end
+    context "異常系" do
+
+      context "スタッフとしてログインしたとき" do
+        context "as a staff" do
+          before do
+            staff = FactoryBot.create(:staff)
+            sign_in staff
+            student = FactoryBot.create(:student, :sample)
+            get :student_edit, params: { student_id: student.id }
+          end
+          context "正常にレスポンスを返さないこと" do
+            it "responds not successfully" do
+              expect(response).not_to be_successful
+            end
+          end
+          context "302レスポンスを返すこと" do
+            it "returns a 302 response" do
+              expect(response).to have_http_status "302"
+            end
+          end
+          context "ルート画面にリダイレクトすること" do
+            it "redirects to the root page" do
+              expect(response).to redirect_to "/"
+            end
+          end
+        end
+      end
+
+      context "セラピスト養成コースの受講生としてログインしたとき" do
+        context "as a therapist training course student" do
+          before do
+            student = FactoryBot.create(:student)
+            sign_in student
+            student = FactoryBot.create(:student, :sample)
+            get :student_edit, params: { student_id: student.id }
+          end
+          context "正常にレスポンスを返さないこと" do
+            it "responds not successfully" do
+              expect(response).not_to be_successful
+            end
+          end
+          context "302レスポンスを返すこと" do
+            it "returns a 302 response" do
+              expect(response).to have_http_status "302"
+            end
+          end
+          context "ルート画面にリダイレクトすること" do
+            it "redirects to the root page" do
+              expect(response).to redirect_to root_path
+            end
+          end
+        end
+      end
+
+      context "セルフケアコースの受講生としてログインしたとき" do
+        context "as a self care course student" do
+          before do
+            student = FactoryBot.create(:student, :self_care)
+            sign_in student
+            student = FactoryBot.create(:student, :sample)
+            get :student_edit, params: { student_id: student.id }
+          end
+          context "正常にレスポンスを返さないこと" do
+            it "responds not successfully" do
+              expect(response).not_to be_successful
+            end
+          end
+          context "302レスポンスを返すこと" do
+            it "returns a 302 response" do
+              expect(response).to have_http_status "302"
+            end
+          end
+          context "ルート画面にリダイレクトすること" do
+            it "redirects to the root page" do
+              expect(response).to redirect_to root_path
+            end
+          end
+        end
+      end
+
+
+      context "ゲストとして" do
+        context "as a guest" do
+          before do
+            student = FactoryBot.create(:student, :sample)
+            get :student_edit, params: { student_id: student.id }
+          end
+          context "正常にレスポンスを返さないこと" do
+            it "responds not successfully" do
+              expect(response).not_to be_successful
+            end
+          end
+          context "302レスポンスを返すこと" do
+            it "returns a 302 response" do
+              expect(response).to have_http_status "302"
+            end
+          end
+          context "ルート画面にリダイレクトすること" do
+            it "redirects to the root page" do
+              expect(response).to redirect_to root_path
             end
           end
         end

--- a/spec/controllers/blogs_controller_spec.rb
+++ b/spec/controllers/blogs_controller_spec.rb
@@ -1,6 +1,206 @@
 require 'rails_helper'
 
 RSpec.describe BlogsController, type: :controller do
+  describe "#new" do
+    context "正常系" do
+      context "管理者は管理者自身のブログにnewでアクセス" do
+        before do
+          admin = FactoryBot.create(:staff, :admin)
+          sign_in admin
+          get :new, params: { staff_id: admin.id }
+        end
+        context "正常にレスポンスを返すこと200レスポンスを返すこと" do
+          it "responds successfully and returns a 200 response" do
+            expect(response).to be_successful
+            expect(response).to have_http_status "200"
+          end
+        end
+      end
+
+      context "管理者はスタッフのブログにnewでアクセス" do
+        before do
+          staff = FactoryBot.create(:staff)
+          admin = FactoryBot.create(:staff, :admin)
+          sign_in admin
+          get :new, params: { staff_id: staff.id }
+        end
+        context "正常にレスポンスを返すこと200レスポンスを返すこと" do
+          it "responds successfully and returns a 200 response" do
+            expect(response).to be_successful
+            expect(response).to have_http_status "200"
+          end
+        end
+      end
+
+      context "スタッフはスタッフ自身のブログにnewでアクセス" do
+        before do
+          staff = FactoryBot.create(:staff)
+          sign_in staff
+          get :new, params: { staff_id: staff.id }
+        end
+        context "正常にレスポンスを返すこと200レスポンスを返すこと" do
+          it "responds successfully and returns a 200 response" do
+            expect(response).to be_successful
+            expect(response).to have_http_status "200"
+          end
+        end
+      end
+    end
+
+    context "異常系" do
+      context "スタッフは管理者のブログにnewでアクセス" do
+        before do
+          admin = FactoryBot.create(:staff, :admin)
+          staff = FactoryBot.create(:staff)
+          sign_in staff
+          get :new, params: { staff_id: admin.id }
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "スタッフは別のスタッフのブログにnewでアクセス" do
+        before do
+          staff = FactoryBot.create(:staff)
+          login_staff = FactoryBot.create(:staff)
+          sign_in login_staff
+          get :new, params: { staff_id: staff.id }
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "セラピスト養成コースの受講生は管理者のブログにnewでアクセス" do
+        before do
+          admin = FactoryBot.create(:staff, :admin)
+          student = FactoryBot.create(:student)
+          sign_in student
+          get :new, params: { staff_id: admin.id }
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "セラピスト養成コースの受講生はスタッフのブログにnewでアクセス" do
+        before do
+          staff = FactoryBot.create(:staff)
+          student = FactoryBot.create(:student)
+          sign_in student
+          get :new, params: { staff_id: staff.id }
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "セルフケアコースの受講生は管理者のブログにnewでアクセス" do
+        before do
+          admin = FactoryBot.create(:staff, :admin)
+          student = FactoryBot.create(:student, :self_care)
+          sign_in student
+          get :new, params: { staff_id: admin.id }
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "セルフケアコースの受講生はスタッフのブログにnewでアクセス" do
+        before do
+          staff = FactoryBot.create(:staff)
+          student = FactoryBot.create(:student, :self_care)
+          sign_in student
+          get :new, params: { staff_id: staff.id }
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "ゲストは管理者のブログにnewでアクセス" do
+        before do
+          admin = FactoryBot.create(:staff, :admin)
+          get :new, params: { staff_id: admin.id }
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "ゲストはスタッフのブログにnewでアクセス" do
+        before do
+          staff = FactoryBot.create(:staff)
+          get :new, params: { staff_id: staff.id }
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+    end
+  end
+
+  describe "#create" do
+    context "正常系" do
+      context "管理者は管理者自身のブログにcreateでアクセス" do
+        before do
+          @admin = FactoryBot.create(:staff, :admin)
+          sign_in @admin
+        end
+        context "正常にレスポンスを返すこと200レスポンスを返すこと" do
+          it "responds successfully and returns a 200 response" do
+            admin_blog_params = FactoryBot.attributes_for(:blog, :admin)
+            expect {
+              post :create, params: { staff_id: @admin.id, blog: admin_blog_params }
+            }.to change(@admin.blogs, :count).by(0)
+            #expect(response).to redirect_to staff_blog_path(id: @admin.id, staff_id: @admin_blog)
+            expect(response).to be_successful
+            expect(response).to have_http_status "200"
+            expect(response).to_not redirect_to "/"
+          end
+        end
+      end
+    end
+  end
+
+
+
+
+
   describe "#edit" do
     context "正常系" do
       context "管理者は管理者自身のブログにeditでアクセス" do
@@ -64,7 +264,7 @@ RSpec.describe BlogsController, type: :controller do
         context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
           it "responds not successfully and returns a 302 response and redirects to the dashboard" do
             expect(response).not_to be_successful
-            expect(response).to redirect_to root_path
+            expect(response).to have_http_status "302"
             expect(response).to redirect_to "/"
           end
         end
@@ -81,7 +281,7 @@ RSpec.describe BlogsController, type: :controller do
         context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
           it "responds not successfully and returns a 302 response and redirects to the dashboard" do
             expect(response).not_to be_successful
-            expect(response).to redirect_to root_path
+            expect(response).to have_http_status "302"
             expect(response).to redirect_to "/"
           end
         end
@@ -98,7 +298,7 @@ RSpec.describe BlogsController, type: :controller do
         context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
           it "responds not successfully and returns a 302 response and redirects to the dashboard" do
             expect(response).not_to be_successful
-            expect(response).to redirect_to root_path
+            expect(response).to have_http_status "302"
             expect(response).to redirect_to "/"
           end
         end
@@ -115,7 +315,7 @@ RSpec.describe BlogsController, type: :controller do
         context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
           it "responds not successfully and returns a 302 response and redirects to the dashboard" do
             expect(response).not_to be_successful
-            expect(response).to redirect_to root_path
+            expect(response).to have_http_status "302"
             expect(response).to redirect_to "/"
           end
         end
@@ -132,7 +332,7 @@ RSpec.describe BlogsController, type: :controller do
         context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
           it "responds not successfully and returns a 302 response and redirects to the dashboard" do
             expect(response).not_to be_successful
-            expect(response).to redirect_to root_path
+            expect(response).to have_http_status "302"
             expect(response).to redirect_to "/"
           end
         end
@@ -149,7 +349,7 @@ RSpec.describe BlogsController, type: :controller do
         context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
           it "responds not successfully and returns a 302 response and redirects to the dashboard" do
             expect(response).not_to be_successful
-            expect(response).to redirect_to root_path
+            expect(response).to have_http_status "302"
             expect(response).to redirect_to "/"
           end
         end
@@ -164,7 +364,7 @@ RSpec.describe BlogsController, type: :controller do
         context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
           it "responds not successfully and returns a 302 response and redirects to the dashboard" do
             expect(response).not_to be_successful
-            expect(response).to redirect_to root_path
+            expect(response).to have_http_status "302"
             expect(response).to redirect_to "/"
           end
         end
@@ -179,15 +379,12 @@ RSpec.describe BlogsController, type: :controller do
         context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
           it "responds not successfully and returns a 302 response and redirects to the dashboard" do
             expect(response).not_to be_successful
-            expect(response).to redirect_to root_path
+            expect(response).to have_http_status "302"
             expect(response).to redirect_to "/"
           end
         end
       end
-
-
     end
-
   end
 
   describe "#update" do
@@ -201,7 +398,7 @@ RSpec.describe BlogsController, type: :controller do
           patch :update, params: {staff_id: admin.id, id: @admin_blog.id, blog: blogs_params }
         end
         context "New Blog Nameに更新されること、詳細ページへリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
-          it "" do
+          it "updated to New Blog Name and redirects to show page and returns 302 response and not redirected to root page" do
             expect(@admin_blog.reload.title).to eq "New Blog Name"
             expect(response).to redirect_to staff_blog_path
             expect(response).to have_http_status "302"
@@ -212,32 +409,40 @@ RSpec.describe BlogsController, type: :controller do
 
       context "管理者はスタッフのブログにupdateでアクセス" do
         before do
-          @blog = FactoryBot.create(:blog)
-          @admin = FactoryBot.create(:staff, :admin)
-        end
-
-        it "responds successfully" do
+          @staff_blog = FactoryBot.create(:blog)
+          staff = Staff.find(@staff_blog.staff_id)
+          admin = FactoryBot.create(:staff, :admin)
+          sign_in admin
           blogs_params = FactoryBot.attributes_for(:blog, title: "New Blog Name")
-          sign_in @admin
-          patch :update, params: {staff_id: @admin.id, id: @blog.id, blog: blogs_params }
-          expect(@blog.reload.title).to eq "New Blog Name"
+          patch :update, params: {staff_id: staff.id, id: @staff_blog.id, blog: blogs_params }
+        end
+        context "New Blog Nameに更新されること、詳細ページへリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "updated to New Blog Name and redirects to show page and returns 302 response and not redirected to root page" do
+            expect(@staff_blog.reload.title).to eq "New Blog Name"
+            expect(response).to redirect_to staff_blog_path
+            expect(response).to have_http_status "302"
+            expect(response).to_not redirect_to "/"
+          end
         end
       end
 
       context "スタッフは自分自身のブログにupdateでアクセス" do
         before do
-          @blog = FactoryBot.create(:blog)
-          @staff = Staff.find(@blog.staff_id)
-        end
-
-        it "responds successfully" do
+          @staff_blog = FactoryBot.create(:blog)
+          staff = Staff.find(@staff_blog.staff_id)
+          sign_in staff
           blogs_params = FactoryBot.attributes_for(:blog, title: "New Blog Name")
-          sign_in @staff
-          patch :update, params: {staff_id: @staff.id, id: @blog.id, blog: blogs_params }
-          expect(@blog.reload.title).to eq "New Blog Name"
+          patch :update, params: {staff_id: staff.id, id: @staff_blog.id, blog: blogs_params }
+        end
+        context "New Blog Nameに更新されること、詳細ページへリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "updated to New Blog Name and redirects to show page and returns 302 response and not redirected to root page" do
+            expect(@staff_blog.reload.title).to eq "New Blog Name"
+            expect(response).to redirect_to staff_blog_path
+            expect(response).to have_http_status "302"
+            expect(response).to_not redirect_to "/"
+          end
         end
       end
-
     end
 
     context "異常系" do
@@ -245,192 +450,359 @@ RSpec.describe BlogsController, type: :controller do
        context "スタッフは管理者のブログにupdateでアクセス" do
         before do
           @admin_blog = FactoryBot.create(:blog, :admin)
-          #puts @admin_blog.title
-          @staff = FactoryBot.create(:staff)
-        end
-
-        it "redirects to the dashboard" do
+          admin = Staff.find(@admin_blog.staff_id)
+          staff = FactoryBot.create(:staff)
+          sign_in staff
           blogs_params = FactoryBot.attributes_for(:blog, title: "New Blog Name")
-          sign_in @staff
-          patch :update, params: {staff_id: @staff.id, id: @admin_blog.id, blog: blogs_params }
-          expect(@admin_blog.reload.title).to eq "title12"
-          expect(response).to redirect_to root_path
+          patch :update, params: {staff_id: admin.id, id: @admin_blog.id, blog: blogs_params }
+        end
+        context "New Blog Nameに更新されないこと、正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトされること" do
+          it "not updated to New Blog Name and responds not successfully and returns a 302 response and redirects to root page" do
+            expect(@admin_blog.reload.title).to_not eq "New Blog Name"
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to root_path
+          end
         end
       end
 
-       context "スタッフは他のスタッフのブログにupdateでアクセス" do
+      context "スタッフは他のスタッフのブログにupdateでアクセス" do
         before do
-          @blog = FactoryBot.create(:blog)
-          @other_staffs_blog = FactoryBot.create(:blog)
-          #puts @other_staffs_blog.title
-          @staff = Staff.find(@blog.staff_id)
-        end
-
-        it "redirects to the dashboard" do
+          @staff_blog = FactoryBot.create(:blog)
+          staff = Staff.find(@staff_blog.staff_id)
+          login_staff = FactoryBot.create(:staff)
+          sign_in login_staff
           blogs_params = FactoryBot.attributes_for(:blog, title: "New Blog Name")
-          sign_in @staff
-          patch :update, params: {staff_id: @staff.id, id: @other_staffs_blog.id, blog: blogs_params }
-          expect(@other_staffs_blog.reload.title).to eq "title14"
-          expect(response).to redirect_to root_path
+          patch :update, params: {staff_id: staff.id, id: @staff_blog.id, blog: blogs_params }
+        end
+        context "New Blog Nameに更新されないこと、正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトされること" do
+          it "not updated to New Blog Name and responds not successfully and returns a 302 response and redirects to root page" do
+            expect(@staff_blog.reload.title).to_not eq "New Blog Name"
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to root_path
+          end
+        end
+      end
+
+      context "セラピスト養成コースの受講生は管理者のブログにupdateでアクセス" do
+        before do
+          @admin_blog = FactoryBot.create(:blog, :admin)
+          admin = Staff.find(@admin_blog.staff_id)
+          student = FactoryBot.create(:student)
+          sign_in student
+          blogs_params = FactoryBot.attributes_for(:blog, title: "New Blog Name")
+          patch :update, params: {staff_id: admin.id, id: @admin_blog.id, blog: blogs_params }
+        end
+        context "New Blog Nameに更新されないこと、正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトされること" do
+          it "not updated to New Blog Name and responds not successfully and returns a 302 response and redirects to root page" do
+            expect(@admin_blog.reload.title).to_not eq "New Blog Name"
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to root_path
+          end
+        end
+      end
+
+      context "セラピスト養成コースの受講生はスタッフのブログにupdateでアクセス" do
+        before do
+          @staff_blog = FactoryBot.create(:blog)
+          staff = Staff.find(@staff_blog.staff_id)
+          student = FactoryBot.create(:student)
+          sign_in student
+          blogs_params = FactoryBot.attributes_for(:blog, title: "New Blog Name")
+          patch :update, params: {staff_id: staff.id, id: @staff_blog.id, blog: blogs_params }
+        end
+        context "New Blog Nameに更新されないこと、正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトされること" do
+          it "not updated to New Blog Name and responds not successfully and returns a 302 response and redirects to root page" do
+            expect(@staff_blog.reload.title).to_not eq "New Blog Name"
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to root_path
+          end
+        end
+      end
+
+      context "セルフケアコースの受講生は管理者のブログにupdateでアクセス" do
+        before do
+          @admin_blog = FactoryBot.create(:blog, :admin)
+          admin = Staff.find(@admin_blog.staff_id)
+          student = FactoryBot.create(:student, :self_care)
+          sign_in student
+          blogs_params = FactoryBot.attributes_for(:blog, title: "New Blog Name")
+          patch :update, params: {staff_id: admin.id, id: @admin_blog.id, blog: blogs_params }
+        end
+        context "New Blog Nameに更新されないこと、正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトされること" do
+          it "not updated to New Blog Name and responds not successfully and returns a 302 response and redirects to root page" do
+            expect(@admin_blog.reload.title).to_not eq "New Blog Name"
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to root_path
+          end
+        end
+      end
+
+      context "セルフケアコースの受講生はスタッフのブログにupdateでアクセス" do
+        before do
+          @staff_blog = FactoryBot.create(:blog)
+          staff = Staff.find(@staff_blog.staff_id)
+          student = FactoryBot.create(:student, :self_care)
+          sign_in student
+          blogs_params = FactoryBot.attributes_for(:blog, title: "New Blog Name")
+          patch :update, params: {staff_id: staff.id, id: @staff_blog.id, blog: blogs_params }
+        end
+        context "New Blog Nameに更新されないこと、正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトされること" do
+          it "not updated to New Blog Name and responds not successfully and returns a 302 response and redirects to root page" do
+            expect(@staff_blog.reload.title).to_not eq "New Blog Name"
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to root_path
+          end
         end
       end
 
       context "ゲストは管理者のブログにupdateでアクセス" do
         before do
           @admin_blog = FactoryBot.create(:blog, :admin)
-          #puts @admin_blog.title
-          @staff = FactoryBot.create(:staff)
-        end
-
-        it "redirects to the dashboard" do
+          admin = Staff.find(@admin_blog.staff_id)
           blogs_params = FactoryBot.attributes_for(:blog, title: "New Blog Name")
-          patch :update, params: {staff_id: @staff.id, id: @admin_blog.id, blog: blogs_params }
-          expect(@admin_blog.reload.title).to eq "title15"
-          expect(response).to redirect_to root_path
+          patch :update, params: {staff_id: admin.id, id: @admin_blog.id, blog: blogs_params }
+        end
+        context "New Blog Nameに更新されないこと、正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトされること" do
+          it "not updated to New Blog Name and responds not successfully and returns a 302 response and redirects to root page" do
+            expect(@admin_blog.reload.title).to_not eq "New Blog Name"
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to root_path
+          end
         end
       end
 
-       context "ゲストはスタッフのブログにupdateでアクセス" do
+      context "ゲストはスタッフのブログにupdateでアクセス" do
         before do
-          @blog = FactoryBot.create(:blog)
-          #puts @blog.title
-          @staff = Staff.find(@blog.staff_id)
-        end
-
-        it "redirects to the dashboard" do
+          @staff_blog = FactoryBot.create(:blog)
+          staff = Staff.find(@staff_blog.staff_id)
           blogs_params = FactoryBot.attributes_for(:blog, title: "New Blog Name")
-          patch :update, params: {staff_id: @staff.id, id: @blog.id, blog: blogs_params }
-          expect(@blog.reload.title).to eq "title16"
-          expect(response).to redirect_to root_path
+          patch :update, params: {staff_id: staff.id, id: @staff_blog.id, blog: blogs_params }
+        end
+        context "New Blog Nameに更新されないこと、正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトされること" do
+          it "not updated to New Blog Name and responds not successfully and returns a 302 response and redirects to root page" do
+            expect(@staff_blog.reload.title).to_not eq "New Blog Name"
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to root_path
+          end
         end
       end
-
-
-
     end
-
   end
 
   describe "#destroy" do
-
     context "正常系" do
-
       context "管理者は管理者自身のブログにdeleteでアクセス" do
         before do
           @admin_blog = FactoryBot.create(:blog, :admin)
           @admin = Staff.find(@admin_blog.staff_id)
-        end
-
-        it "responds successfully" do
           sign_in @admin
-          expect {
-            delete :destroy, params: {staff_id: @admin.id, id: @admin_blog.id}
-          }.to change(@admin.blogs, :count).by(-1)
+        end
+        context "削除されること、staff_blogs画面にリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "admin deletes blog and redirect to blogs page and returns a 200 response and does not redirect to root page" do
+            expect {
+              delete :destroy, params: {staff_id: @admin.id, id: @admin_blog.id}
+            }.to change(@admin.blogs, :count).by(-1)
+            expect(response).to redirect_to staff_blogs_path
+            expect(response).to have_http_status "302"
+            expect(response).to_not redirect_to "/"
+          end
         end
       end
 
       context "管理者はスタッフのブログにdeleteでアクセス" do
         before do
-          @blog = FactoryBot.create(:blog)
-          @staff = Staff.find(@blog.staff_id)
-          @admin = FactoryBot.create(:staff, :admin)
+          @staff_blog = FactoryBot.create(:blog, :admin)
+          @staff = Staff.find(@staff_blog.staff_id)
+          admin = FactoryBot.create(:staff, :admin)
+          sign_in admin
         end
-
-        it "responds successfully" do
-          sign_in @admin
-          expect {
-            delete :destroy, params: {staff_id: @admin.id, id: @blog.id}
-          }.to change(@staff.blogs, :count).by(-1)
+        context "削除されること、staff_blogs画面にリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "admin deletes blog and redirect to blogs page and returns a 200 response and does not redirect to root page" do
+            expect {
+              delete :destroy, params: {staff_id: @staff.id, id: @staff_blog.id}
+            }.to change(@staff.blogs, :count).by(-1)
+            expect(response).to redirect_to staff_blogs_path
+            expect(response).to have_http_status "302"
+            expect(response).to_not redirect_to "/"
+          end
         end
       end
 
       context "スタッフは自分自身のブログにdeleteでアクセス" do
         before do
-          @blog = FactoryBot.create(:blog)
-          @staff = Staff.find(@blog.staff_id)
-        end
-
-        it "responds successfully" do
+          @staff_blog = FactoryBot.create(:blog, :admin)
+          @staff = Staff.find(@staff_blog.staff_id)
           sign_in @staff
-          expect {
-            delete :destroy, params: {staff_id: @staff.id, id: @blog.id}
-          }.to change(@staff.blogs, :count).by(-1)
+        end
+        context "削除されること、staff_blogs画面にリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "admin deletes blog and redirect to blogs page and returns a 200 response and does not redirect to root page" do
+            expect {
+              delete :destroy, params: {staff_id: @staff.id, id: @staff_blog.id}
+            }.to change(@staff.blogs, :count).by(-1)
+            expect(response).to redirect_to staff_blogs_path
+            expect(response).to have_http_status "302"
+            expect(response).to_not redirect_to "/"
+          end
         end
       end
-
     end
 
     context "異常系" do
-
       context "スタッフは管理者のブログにdeleteでアクセス" do
         before do
           @admin_blog = FactoryBot.create(:blog, :admin)
-          @staff = FactoryBot.create(:staff)
+          @admin = Staff.find(@admin_blog.staff_id)
+          staff = FactoryBot.create(:staff)
+          sign_in staff
         end
-
-        it "redirects to the dashboard " do
-          sign_in @staff
-          expect {
-            delete :destroy, params: {staff_id: @staff.id, id: @admin_blog.id}
-          }.to_not change(Blog, :count)
-          expect(response).to redirect_to root_path
+        context "削除されること、staff_blogs画面にリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "admin deletes blog and redirect to blogs page and returns a 200 response and does not redirect to root page" do
+            expect {
+              delete :destroy, params: {staff_id: @admin.id, id: @admin_blog.id}
+            }.to_not change(@admin.blogs, :count)
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
         end
       end
 
       context "スタッフは他のスタッフのブログにdeleteでアクセス" do
         before do
-          @blog = FactoryBot.create(:blog)
-          @other_staffs_blog = FactoryBot.create(:blog)
-          @staff = Staff.find(@blog.staff_id)
+          @staff_blog = FactoryBot.create(:blog)
+          @staff = Staff.find(@staff_blog.staff_id)
+          login_staff = FactoryBot.create(:staff)
+          sign_in login_staff
         end
+        context "削除されること、staff_blogs画面にリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "admin deletes blog and redirect to blogs page and returns a 200 response and does not redirect to root page" do
+            expect {
+              delete :destroy, params: {staff_id: @staff.id, id: @staff_blog.id}
+            }.to_not change(@staff.blogs, :count)
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
 
-        it "redirects to the dashboard " do
-          sign_in @staff
-          expect {
-            delete :destroy, params: {staff_id: @staff.id, id: @other_staffs_blog.id}
-          }.to_not change(Blog, :count)
-          expect(response).to redirect_to root_path
+      context "セラピスト養成コースの受講生は管理者のブログにdeleteでアクセス" do
+        before do
+          @admin_blog = FactoryBot.create(:blog, :admin)
+          @admin = Staff.find(@admin_blog.staff_id)
+          student = FactoryBot.create(:student)
+          sign_in student
+        end
+        context "削除されること、staff_blogs画面にリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "admin deletes blog and redirect to blogs page and returns a 200 response and does not redirect to root page" do
+            expect {
+              delete :destroy, params: {staff_id: @admin.id, id: @admin_blog.id}
+            }.to_not change(@admin.blogs, :count)
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "セラピスト養成コースの受講生はスタッフのブログにdeleteでアクセス" do
+        before do
+          @staff_blog = FactoryBot.create(:blog)
+          @staff = Staff.find(@staff_blog.staff_id)
+          student = FactoryBot.create(:student)
+          sign_in student
+        end
+        context "削除されること、staff_blogs画面にリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "admin deletes blog and redirect to blogs page and returns a 200 response and does not redirect to root page" do
+            expect {
+              delete :destroy, params: {staff_id: @staff.id, id: @staff_blog.id}
+            }.to_not change(@staff.blogs, :count)
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "セルフケアコースの受講生は管理者のブログにdeleteでアクセス" do
+        before do
+          @admin_blog = FactoryBot.create(:blog, :admin)
+          @admin = Staff.find(@admin_blog.staff_id)
+          student = FactoryBot.create(:student, :self_care)
+          sign_in student
+        end
+        context "削除されること、staff_blogs画面にリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "admin deletes blog and redirect to blogs page and returns a 200 response and does not redirect to root page" do
+            expect {
+              delete :destroy, params: {staff_id: @admin.id, id: @admin_blog.id}
+            }.to_not change(@admin.blogs, :count)
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "セルフケアコースの受講生はスタッフのブログにdeleteでアクセス" do
+        before do
+          @staff_blog = FactoryBot.create(:blog)
+          @staff = Staff.find(@staff_blog.staff_id)
+          student = FactoryBot.create(:student, :self_care)
+          sign_in student
+        end
+        context "削除されること、staff_blogs画面にリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "admin deletes blog and redirect to blogs page and returns a 200 response and does not redirect to root page" do
+            expect {
+              delete :destroy, params: {staff_id: @staff.id, id: @staff_blog.id}
+            }.to_not change(@staff.blogs, :count)
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
         end
       end
 
       context "ゲストは管理者のブログにdeleteでアクセス" do
         before do
           @admin_blog = FactoryBot.create(:blog, :admin)
-          @staff = FactoryBot.create(:staff)
+          @admin = Staff.find(@admin_blog.staff_id)
         end
-
-        it "redirects to the dashboard " do
-          expect {
-            delete :destroy, params: {staff_id: @staff.id, id: @admin_blog.id}
-          }.to_not change(Blog, :count)
-          expect(response).to redirect_to root_path
+        context "削除されること、staff_blogs画面にリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "admin deletes blog and redirect to blogs page and returns a 200 response and does not redirect to root page" do
+            expect {
+              delete :destroy, params: {staff_id: @admin.id, id: @admin_blog.id}
+            }.to_not change(@admin.blogs, :count)
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
         end
       end
 
       context "ゲストはスタッフのブログにdeleteでアクセス" do
         before do
-          @blog = FactoryBot.create(:blog)
-          @staff = Staff.find(@blog.staff_id)
-          #blog = FactoryBot.create(:blog)
-          blog = []
-          1.upto 4 do |n|
-            blog[n] = FactoryBot.create(:blog)
-          end
-          #puts blog[4].datetime
+          @staff_blog = FactoryBot.create(:blog)
+          @staff = Staff.find(@staff_blog.staff_id)
         end
-
-        it "redirects to the dashboard " do
-          expect {
-            delete :destroy, params: {staff_id: @staff.id, id: @blog.id}
-          }.to_not change(Blog, :count)
-          expect(response).to redirect_to root_path
+        context "削除されること、staff_blogs画面にリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "admin deletes blog and redirect to blogs page and returns a 200 response and does not redirect to root page" do
+            expect {
+              delete :destroy, params: {staff_id: @staff.id, id: @staff_blog.id}
+            }.to_not change(@staff.blogs, :count)
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
         end
       end
-
-
-
-
-
     end
   end
 end

--- a/spec/controllers/blogs_controller_spec.rb
+++ b/spec/controllers/blogs_controller_spec.rb
@@ -1,47 +1,51 @@
 require 'rails_helper'
 
 RSpec.describe BlogsController, type: :controller do
-
   describe "#edit" do
-
     context "正常系" do
-
       context "管理者は管理者自身のブログにeditでアクセス" do
         before do
-          @admin_blog = FactoryBot.create(:blog, :admin)
-          @admin = Staff.find(@admin_blog.staff_id)
+          admin_blog = FactoryBot.create(:blog, :admin)
+          admin = Staff.find(admin_blog.staff_id)
+          sign_in admin
+          get :edit, params: { staff_id: admin.id, id: admin_blog.id }
         end
-
-        it "responds successfully" do
-          sign_in @admin
-          get :edit, params: { staff_id: @admin.id, id: @admin_blog.id }
-          expect(response).to be_successful
+        context "正常にレスポンスを返すこと200レスポンスを返すこと" do
+          it "responds successfully and returns a 200 response" do
+            expect(response).to be_successful
+            expect(response).to have_http_status "200"
+          end
         end
       end
 
       context "管理者はスタッフのブログにeditでアクセス" do
         before do
-          @blog = FactoryBot.create(:blog)
-          @admin = FactoryBot.create(:staff, :admin)
+          staff_blog = FactoryBot.create(:blog)
+          staff = Staff.find(staff_blog.staff_id)
+          admin = FactoryBot.create(:staff, :admin)
+          sign_in admin
+          get :edit, params: { staff_id: staff.id, id: staff_blog.id }
         end
-
-        it "responds successfully" do
-          sign_in @admin
-          get :edit, params: { staff_id: @admin.id, id: @blog.id }
-          expect(response).to be_successful
+        context "正常にレスポンスを返すこと200レスポンスを返すこと" do
+          it "responds successfully and returns a 200 response" do
+           expect(response).to be_successful
+           expect(response).to have_http_status "200"
+          end
         end
       end
 
       context "スタッフは自分自身のブログにeditでアクセス" do
         before do
-          @blog = FactoryBot.create(:blog)
-          @staff = Staff.find(@blog.staff_id)
+          staff_blog = FactoryBot.create(:blog)
+          staff = Staff.find(staff_blog.staff_id)
+          sign_in staff
+          get :edit, params: { staff_id: staff.id, id: staff_blog.id }
         end
-
-        it "responds successfully" do
-          sign_in @staff
-          get :edit, params: { staff_id: @staff.id, id: @blog.id }
-          expect(response).to be_successful
+        context "正常にレスポンスを返すこと200レスポンスを返すこと" do
+          it "responds successfully and returns a 200 response" do
+            expect(response).to be_successful
+            expect(response).to have_http_status "200"
+          end
         end
       end
 
@@ -51,52 +55,133 @@ RSpec.describe BlogsController, type: :controller do
 
        context "スタッフは管理者のブログにeditでアクセス" do
         before do
-          @admin_blog = FactoryBot.create(:blog, :admin)
-          @staff = FactoryBot.create(:staff)
+          admin_blog = FactoryBot.create(:blog, :admin)
+          admin = Staff.find(admin_blog.staff_id)
+          staff = FactoryBot.create(:staff)
+          sign_in staff
+          get :edit, params: { staff_id: admin.id, id: admin_blog.id }
         end
-
-        it "redirects to the dashboard" do
-          sign_in @staff
-          get :edit, params: { staff_id: @staff.id, id: @admin_blog.id }
-          expect(response).to redirect_to root_path
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+            expect(response).not_to be_successful
+            expect(response).to redirect_to root_path
+            expect(response).to redirect_to "/"
+          end
         end
       end
 
       context "スタッフは他のスタッフのブログにeditでアクセス" do
         before do
-          @blog = FactoryBot.create(:blog)
-          @other_staffs_blog = FactoryBot.create(:blog)
-          @staff = Staff.find(@blog.staff_id)
+          staff_blog = FactoryBot.create(:blog)
+          staff = Staff.find(staff_blog.staff_id)
+          login_staff = FactoryBot.create(:staff)
+          sign_in login_staff
+          get :edit, params: { staff_id: staff.id, id: staff_blog.id }
         end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+            expect(response).not_to be_successful
+            expect(response).to redirect_to root_path
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
 
-        it "redirects to the dashboard" do
-          sign_in @staff
-          get :edit, params: { staff_id: @staff.id, id: @other_staffs_blog.id }
-          expect(response).to redirect_to root_path
+      context "セラピスト養成コースの受講生は管理者のブログにeditでアクセス" do
+        before do
+          admin_blog = FactoryBot.create(:blog, :admin)
+          admin = Staff.find(admin_blog.staff_id)
+          student = FactoryBot.create(:student)
+          sign_in student
+          get :edit, params: { staff_id: admin.id, id: admin_blog.id }
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+            expect(response).not_to be_successful
+            expect(response).to redirect_to root_path
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "セラピスト養成コースの受講生はスタッフのブログにeditでアクセス" do
+        before do
+          staff_blog = FactoryBot.create(:blog)
+          staff = Staff.find(staff_blog.staff_id)
+          student = FactoryBot.create(:student)
+          sign_in student
+          get :edit, params: { staff_id: staff.id, id: staff_blog.id }
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+            expect(response).not_to be_successful
+            expect(response).to redirect_to root_path
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "セルフケアコースの受講生は管理者のブログにeditでアクセス" do
+        before do
+          admin_blog = FactoryBot.create(:blog, :admin)
+          admin = Staff.find(admin_blog.staff_id)
+          student = FactoryBot.create(:student, :self_care)
+          sign_in student
+          get :edit, params: { staff_id: admin.id, id: admin_blog.id }
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+            expect(response).not_to be_successful
+            expect(response).to redirect_to root_path
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "セルフケアコースの受講生はスタッフのブログにeditでアクセス" do
+        before do
+          staff_blog = FactoryBot.create(:blog)
+          staff = Staff.find(staff_blog.staff_id)
+          student = FactoryBot.create(:student, :self_care)
+          sign_in student
+          get :edit, params: { staff_id: staff.id, id: staff_blog.id }
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+            expect(response).not_to be_successful
+            expect(response).to redirect_to root_path
+            expect(response).to redirect_to "/"
+          end
         end
       end
 
       context "ゲストは管理者のブログにeditでアクセス" do
         before do
-          @admin_blog = FactoryBot.create(:blog, :admin)
-          @staff = FactoryBot.create(:staff)
+          admin_blog = FactoryBot.create(:blog, :admin)
+          admin = Staff.find(admin_blog.staff_id)
+          get :edit, params: { staff_id: admin.id, id: admin_blog.id }
         end
-
-        it "redirects to the dashboard" do
-          get :edit, params: { staff_id: @staff.id, id: @admin_blog.id }
-          expect(response).to redirect_to root_path
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+            expect(response).not_to be_successful
+            expect(response).to redirect_to root_path
+            expect(response).to redirect_to "/"
+          end
         end
       end
 
       context "ゲストはスタッフのブログにeditでアクセス" do
         before do
-          @blog = FactoryBot.create(:blog)
-          @staff = Staff.find(@blog.staff_id)
+          staff_blog = FactoryBot.create(:blog)
+          staff = Staff.find(staff_blog.staff_id)
+          get :edit, params: { staff_id: staff.id, id: staff_blog.id }
         end
-
-        it "redirects to the dashboard" do
-          get :edit, params: { staff_id: @staff.id, id: @blog.id }
-          expect(response).to redirect_to root_path
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+            expect(response).not_to be_successful
+            expect(response).to redirect_to root_path
+            expect(response).to redirect_to "/"
+          end
         end
       end
 
@@ -106,20 +191,22 @@ RSpec.describe BlogsController, type: :controller do
   end
 
   describe "#update" do
-
     context "正常系" do
-
       context "管理者は管理者自身のブログにupdateでアクセス" do
         before do
           @admin_blog = FactoryBot.create(:blog, :admin)
-          @admin = Staff.find(@admin_blog.staff_id)
-        end
-
-        it "responds successfully" do
+          admin = Staff.find(@admin_blog.staff_id)
+          sign_in admin
           blogs_params = FactoryBot.attributes_for(:blog, title: "New Blog Name")
-          sign_in @admin
-          patch :update, params: {staff_id: @admin.id, id: @admin_blog.id, blog: blogs_params }
-          expect(@admin_blog.reload.title).to eq "New Blog Name"
+          patch :update, params: {staff_id: admin.id, id: @admin_blog.id, blog: blogs_params }
+        end
+        context "New Blog Nameに更新されること、詳細ページへリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "" do
+            expect(@admin_blog.reload.title).to eq "New Blog Name"
+            expect(response).to redirect_to staff_blog_path
+            expect(response).to have_http_status "302"
+            expect(response).to_not redirect_to "/"
+          end
         end
       end
 

--- a/spec/controllers/blogs_controller_spec.rb
+++ b/spec/controllers/blogs_controller_spec.rb
@@ -9,10 +9,11 @@ RSpec.describe BlogsController, type: :controller do
           sign_in admin
           get :new, params: { staff_id: admin.id }
         end
-        context "正常にレスポンスを返すこと200レスポンスを返すこと" do
+        context "正常にレスポンスを返すこと、200レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
           it "responds successfully and returns a 200 response" do
             expect(response).to be_successful
             expect(response).to have_http_status "200"
+            expect(response).to_not redirect_to "/"
           end
         end
       end
@@ -24,10 +25,11 @@ RSpec.describe BlogsController, type: :controller do
           sign_in admin
           get :new, params: { staff_id: staff.id }
         end
-        context "正常にレスポンスを返すこと200レスポンスを返すこと" do
+        context "正常にレスポンスを返すこと、200レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
           it "responds successfully and returns a 200 response" do
             expect(response).to be_successful
             expect(response).to have_http_status "200"
+            expect(response).to_not redirect_to "/"
           end
         end
       end
@@ -38,10 +40,11 @@ RSpec.describe BlogsController, type: :controller do
           sign_in staff
           get :new, params: { staff_id: staff.id }
         end
-        context "正常にレスポンスを返すこと200レスポンスを返すこと" do
+        context "正常にレスポンスを返すこと、200レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
           it "responds successfully and returns a 200 response" do
             expect(response).to be_successful
             expect(response).to have_http_status "200"
+            expect(response).to_not redirect_to "/"
           end
         end
       end
@@ -56,7 +59,7 @@ RSpec.describe BlogsController, type: :controller do
           get :new, params: { staff_id: admin.id }
         end
         context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
-          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
             expect(response).not_to be_successful
             expect(response).to have_http_status "302"
             expect(response).to redirect_to "/"
@@ -72,7 +75,7 @@ RSpec.describe BlogsController, type: :controller do
           get :new, params: { staff_id: staff.id }
         end
         context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
-          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
             expect(response).not_to be_successful
             expect(response).to have_http_status "302"
             expect(response).to redirect_to "/"
@@ -88,7 +91,7 @@ RSpec.describe BlogsController, type: :controller do
           get :new, params: { staff_id: admin.id }
         end
         context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
-          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
             expect(response).not_to be_successful
             expect(response).to have_http_status "302"
             expect(response).to redirect_to "/"
@@ -104,7 +107,7 @@ RSpec.describe BlogsController, type: :controller do
           get :new, params: { staff_id: staff.id }
         end
         context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
-          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
             expect(response).not_to be_successful
             expect(response).to have_http_status "302"
             expect(response).to redirect_to "/"
@@ -120,7 +123,7 @@ RSpec.describe BlogsController, type: :controller do
           get :new, params: { staff_id: admin.id }
         end
         context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
-          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
             expect(response).not_to be_successful
             expect(response).to have_http_status "302"
             expect(response).to redirect_to "/"
@@ -136,7 +139,7 @@ RSpec.describe BlogsController, type: :controller do
           get :new, params: { staff_id: staff.id }
         end
         context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
-          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
             expect(response).not_to be_successful
             expect(response).to have_http_status "302"
             expect(response).to redirect_to "/"
@@ -150,7 +153,7 @@ RSpec.describe BlogsController, type: :controller do
           get :new, params: { staff_id: admin.id }
         end
         context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
-          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
             expect(response).not_to be_successful
             expect(response).to have_http_status "302"
             expect(response).to redirect_to "/"
@@ -164,7 +167,7 @@ RSpec.describe BlogsController, type: :controller do
           get :new, params: { staff_id: staff.id }
         end
         context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
-          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
             expect(response).not_to be_successful
             expect(response).to have_http_status "302"
             expect(response).to redirect_to "/"
@@ -181,13 +184,55 @@ RSpec.describe BlogsController, type: :controller do
           @admin = FactoryBot.create(:staff, :admin)
           sign_in @admin
         end
-        context "正常にレスポンスを返すこと200レスポンスを返すこと" do
-          it "responds successfully and returns a 200 response" do
+        context "正常にレスポンスを返すこと、200レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "responds successfully and returns a 200 response and not redirected to root page" do
+            #admin_blog_params = FactoryBot.attributes_for(:blog, staff: @admin)
+            #admin_blog_params = FactoryBot.attributes_for(:blog, owner: @admin)
+            #admin_blog_params = FactoryBot.attributes_for(:blog, :admin, title: "New Blog title")
             admin_blog_params = FactoryBot.attributes_for(:blog, :admin)
+            #admin =  Staff.find(admin_blog_params[:staff].id)
+            #puts admin.name
+            #sign_in admin
             expect {
               post :create, params: { staff_id: @admin.id, blog: admin_blog_params }
             }.to change(@admin.blogs, :count).by(0)
-            #expect(response).to redirect_to staff_blog_path(id: @admin.id, staff_id: @admin_blog)
+            #}.to change(Blog, :count).by(0)
+            expect(response).to be_successful
+            expect(response).to have_http_status "200"
+            expect(response).to_not redirect_to "/"
+          end
+        end
+      end
+      context "管理者はスタッフのブログにcreateでアクセス" do
+        before do
+          @admin = FactoryBot.create(:staff, :admin)
+          sign_in @admin
+          @staff = FactoryBot.create(:staff)
+        end
+        context "正常にレスポンスを返すこと、200レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "responds successfully and returns a 200 response and not redirected to root page" do
+            blog_params = FactoryBot.attributes_for(:blog)
+            expect {
+              post :create, params: { staff_id: @staff.id, blog: blog_params }
+            }.to change(@staff.blogs, :count).by(0)
+            expect(response).to be_successful
+            expect(response).to have_http_status "200"
+            expect(response).to_not redirect_to "/"
+          end
+        end
+      end
+
+      context "スタッフは自分自身ののブログにcreateでアクセス" do
+        before do
+          @staff = FactoryBot.create(:staff)
+          sign_in @staff
+        end
+        context "正常にレスポンスを返すこと、200レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "responds successfully and returns a 200 response and not redirected to root page" do
+            blog_params = FactoryBot.attributes_for(:blog)
+            expect {
+              post :create, params: { staff_id: @staff.id, blog: blog_params }
+            }.to change(@staff.blogs, :count).by(0)
             expect(response).to be_successful
             expect(response).to have_http_status "200"
             expect(response).to_not redirect_to "/"
@@ -195,11 +240,157 @@ RSpec.describe BlogsController, type: :controller do
         end
       end
     end
+
+    context "異常系" do
+      context "スタッフは管理者のブログにcreateでアクセス" do
+        before do
+          staff = FactoryBot.create(:staff)
+          sign_in staff
+          @admin = FactoryBot.create(:staff, :admin)
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            admin_blog_params = FactoryBot.attributes_for(:blog, :admin)
+            expect {
+              post :create, params: { staff_id: @admin.id, blog: admin_blog_params }
+            }.to change(@admin.blogs, :count).by(0)
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "スタッフは別のスタッフのブログにcreateでアクセス" do
+        before do
+          login_staff = FactoryBot.create(:staff)
+          sign_in login_staff
+          @staff = FactoryBot.create(:staff)
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            blog_params = FactoryBot.attributes_for(:blog)
+            expect {
+              post :create, params: { staff_id: @staff.id, blog: blog_params }
+            }.to change(@staff.blogs, :count).by(0)
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+     context "セラピスト養成コースの受講生は管理者のブログにcreateでアクセス" do
+        before do
+          student = FactoryBot.create(:student)
+          sign_in student
+          @admin = FactoryBot.create(:staff, :admin)
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            admin_blog_params = FactoryBot.attributes_for(:blog, :admin)
+            expect {
+              post :create, params: { staff_id: @admin.id, blog: admin_blog_params }
+            }.to change(@admin.blogs, :count).by(0)
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+     context "セラピスト養成コースの受講生はスタッフのブログにcreateでアクセス" do
+        before do
+          student = FactoryBot.create(:student)
+          sign_in student
+          @staff = FactoryBot.create(:staff)
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            blog_params = FactoryBot.attributes_for(:blog)
+            expect {
+              post :create, params: { staff_id: @staff.id, blog: blog_params }
+            }.to change(@staff.blogs, :count).by(0)
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+     context "セルフケアコースの受講生は管理者のブログにcreateでアクセス" do
+        before do
+          student = FactoryBot.create(:student, :self_care)
+          sign_in student
+          @admin = FactoryBot.create(:staff, :admin)
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            admin_blog_params = FactoryBot.attributes_for(:blog, :admin)
+            expect {
+              post :create, params: { staff_id: @admin.id, blog: admin_blog_params }
+            }.to change(@admin.blogs, :count).by(0)
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+     context "セルフケアコースの受講生はスタッフのブログにcreateでアクセス" do
+        before do
+          student = FactoryBot.create(:student, :self_care)
+          sign_in student
+          @staff = FactoryBot.create(:staff)
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            blog_params = FactoryBot.attributes_for(:blog)
+            expect {
+              post :create, params: { staff_id: @staff.id, blog: blog_params }
+            }.to change(@staff.blogs, :count).by(0)
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+     context "ゲストは管理者のブログにcreateでアクセス" do
+        before do
+          @admin = FactoryBot.create(:staff, :admin)
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            admin_blog_params = FactoryBot.attributes_for(:blog, :admin)
+            expect {
+              post :create, params: { staff_id: @admin.id, blog: admin_blog_params }
+            }.to change(@admin.blogs, :count).by(0)
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+     context "ゲストはスタッフのブログにcreateでアクセス" do
+        before do
+          @staff = FactoryBot.create(:staff)
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            blog_params = FactoryBot.attributes_for(:blog)
+            expect {
+              post :create, params: { staff_id: @staff.id, blog: blog_params }
+            }.to change(@staff.blogs, :count).by(0)
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+    end
   end
-
-
-
-
 
   describe "#edit" do
     context "正常系" do
@@ -210,10 +401,11 @@ RSpec.describe BlogsController, type: :controller do
           sign_in admin
           get :edit, params: { staff_id: admin.id, id: admin_blog.id }
         end
-        context "正常にレスポンスを返すこと200レスポンスを返すこと" do
+        context "正常にレスポンスを返すこと、200レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
           it "responds successfully and returns a 200 response" do
             expect(response).to be_successful
             expect(response).to have_http_status "200"
+            expect(response).to_not redirect_to "/"
           end
         end
       end
@@ -226,10 +418,11 @@ RSpec.describe BlogsController, type: :controller do
           sign_in admin
           get :edit, params: { staff_id: staff.id, id: staff_blog.id }
         end
-        context "正常にレスポンスを返すこと200レスポンスを返すこと" do
+        context "正常にレスポンスを返すこと、200レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
           it "responds successfully and returns a 200 response" do
            expect(response).to be_successful
            expect(response).to have_http_status "200"
+           expect(response).to_not redirect_to "/"
           end
         end
       end
@@ -241,10 +434,11 @@ RSpec.describe BlogsController, type: :controller do
           sign_in staff
           get :edit, params: { staff_id: staff.id, id: staff_blog.id }
         end
-        context "正常にレスポンスを返すこと200レスポンスを返すこと" do
+        context "正常にレスポンスを返すこと、200レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
           it "responds successfully and returns a 200 response" do
             expect(response).to be_successful
             expect(response).to have_http_status "200"
+            expect(response).to_not redirect_to "/"
           end
         end
       end
@@ -252,7 +446,6 @@ RSpec.describe BlogsController, type: :controller do
     end
 
     context "異常系" do
-
        context "スタッフは管理者のブログにeditでアクセス" do
         before do
           admin_blog = FactoryBot.create(:blog, :admin)
@@ -262,7 +455,7 @@ RSpec.describe BlogsController, type: :controller do
           get :edit, params: { staff_id: admin.id, id: admin_blog.id }
         end
         context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
-          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
             expect(response).not_to be_successful
             expect(response).to have_http_status "302"
             expect(response).to redirect_to "/"
@@ -279,7 +472,7 @@ RSpec.describe BlogsController, type: :controller do
           get :edit, params: { staff_id: staff.id, id: staff_blog.id }
         end
         context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
-          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
             expect(response).not_to be_successful
             expect(response).to have_http_status "302"
             expect(response).to redirect_to "/"
@@ -296,7 +489,7 @@ RSpec.describe BlogsController, type: :controller do
           get :edit, params: { staff_id: admin.id, id: admin_blog.id }
         end
         context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
-          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
             expect(response).not_to be_successful
             expect(response).to have_http_status "302"
             expect(response).to redirect_to "/"
@@ -313,7 +506,7 @@ RSpec.describe BlogsController, type: :controller do
           get :edit, params: { staff_id: staff.id, id: staff_blog.id }
         end
         context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
-          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
             expect(response).not_to be_successful
             expect(response).to have_http_status "302"
             expect(response).to redirect_to "/"
@@ -330,7 +523,7 @@ RSpec.describe BlogsController, type: :controller do
           get :edit, params: { staff_id: admin.id, id: admin_blog.id }
         end
         context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
-          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
             expect(response).not_to be_successful
             expect(response).to have_http_status "302"
             expect(response).to redirect_to "/"
@@ -347,7 +540,7 @@ RSpec.describe BlogsController, type: :controller do
           get :edit, params: { staff_id: staff.id, id: staff_blog.id }
         end
         context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
-          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
             expect(response).not_to be_successful
             expect(response).to have_http_status "302"
             expect(response).to redirect_to "/"
@@ -362,7 +555,7 @@ RSpec.describe BlogsController, type: :controller do
           get :edit, params: { staff_id: admin.id, id: admin_blog.id }
         end
         context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
-          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
             expect(response).not_to be_successful
             expect(response).to have_http_status "302"
             expect(response).to redirect_to "/"
@@ -377,7 +570,7 @@ RSpec.describe BlogsController, type: :controller do
           get :edit, params: { staff_id: staff.id, id: staff_blog.id }
         end
         context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
-          it "responds not successfully and returns a 302 response and redirects to the dashboard" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
             expect(response).not_to be_successful
             expect(response).to have_http_status "302"
             expect(response).to redirect_to "/"

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -74,6 +74,14 @@ RSpec.describe StudentsController, type: :controller do
             end
           end
 
+          context "ルート画面にリダイレクトすること" do
+            it "redirects to the root page" do
+              expect(response).to redirect_to "/"
+            end
+          end
+        end
+      end
+
       context "セルフケアコースの受講生としてログインしたとき" do
         context "as a self care coure student" do
           before do
@@ -99,16 +107,7 @@ RSpec.describe StudentsController, type: :controller do
               expect(response).to redirect_to root_path
             end
           end
-        end
-      end
 
-
-
-          context "ルート画面にリダイレクトすること" do
-            it "redirects to the root page" do
-              expect(response).to redirect_to root_path
-            end
-          end
         end
       end
 
@@ -196,31 +195,10 @@ RSpec.describe StudentsController, type: :controller do
       context "セラピスト養成コースの受講生としてログインしたとき" do
         context "as a therapist training course student" do
           before do
+            login_student = FactoryBot.create(:student)
+            sign_in login_student
             student = FactoryBot.create(:student)
-            sign_in student
-            another_student = FactoryBot.create(:student)
-            get :show, params: { id: another_student.id }
-          end
-
-          context "正常にレスポンスを返さないこと" do
-            it "responds not successfully" do
-              expect(response).not_to be_successful
-            end
-          end
-
-          context "302レスポンスを返すこと" do
-            it "returns a 302 response" do
-              expect(response).to have_http_status "302"
-            end
-          end
-
-      context "セルフケアコースの受講生としてログインしたとき" do
-        context "as a self care course student" do
-          before do
-            student = FactoryBot.create(:student, :self_care)
-            sign_in student
-            another_student = FactoryBot.create(:student)
-            get :show, params: { id: another_student.id }
+            get :show, params: { id: student.id }
           end
 
           context "正常にレスポンスを返さないこと" do
@@ -243,14 +221,34 @@ RSpec.describe StudentsController, type: :controller do
         end
       end
 
+      context "セルフケアコースの受講生としてログインしたとき" do
+        context "as a self care course student" do
+          before do
+            login_student = FactoryBot.create(:student, :self_care)
+            sign_in login_student
+            student = FactoryBot.create(:student)
+            get :show, params: { id: student.id }
+          end
 
+          context "正常にレスポンスを返さないこと" do
+            it "responds not successfully" do
+              expect(response).not_to be_successful
+            end
+          end
+
+          context "302レスポンスを返すこと" do
+            it "returns a 302 response" do
+              expect(response).to have_http_status "302"
+            end
+          end
 
           context "ルート画面にリダイレクトすること" do
             it "redirects to the root page" do
               expect(response).to redirect_to root_path
             end
           end
-        end
+
+       end
       end
 
       context "ゲストとして" do
@@ -319,8 +317,8 @@ RSpec.describe StudentsController, type: :controller do
       context "スタッフとしてログインしたとき" do
         context "as a staff" do
           before do
-            @staff = FactoryBot.create(:staff)
-            sign_in @staff
+            staff = FactoryBot.create(:staff)
+            sign_in staff
             @student = FactoryBot.create(:student)
             student_params = FactoryBot.attributes_for(:student, name: "abc")
             patch :update, params: { id: @student.id, student: student_params }
@@ -351,15 +349,15 @@ RSpec.describe StudentsController, type: :controller do
       context "セラピスト養成コースの受講生としてログインしたとき" do
         context "as a therapist training course student" do
           before do
-            student = FactoryBot.create(:student)
-            sign_in student
-            @another_student = FactoryBot.create(:student)
+            login_student = FactoryBot.create(:student)
+            sign_in login_student
+            @student = FactoryBot.create(:student)
             student_params = FactoryBot.attributes_for(:student, name: "abc")
-            patch :update, params: { id: @another_student.id, student: student_params }
+            patch :update, params: { id: @student.id, student: student_params }
           end
           context "abcに更新されないこと" do
             it "not updated to abc" do
-              expect(@another_student.reload.name).to_not eq "abc"
+              expect(@student.reload.name).to_not eq "abc"
             end
           end
           context "正常にレスポンスを返さないこと" do
@@ -383,15 +381,15 @@ RSpec.describe StudentsController, type: :controller do
       context "セルフケアコースの受講生としてログインしたとき" do
         context "as a self care course student" do
           before do
-            student = FactoryBot.create(:student, :self_care)
-            sign_in student
-            @another_student = FactoryBot.create(:student)
+            login_student = FactoryBot.create(:student, :self_care)
+            sign_in login_student
+            @student = FactoryBot.create(:student)
             student_params = FactoryBot.attributes_for(:student, name: "abc")
-            patch :update, params: { id: @another_student.id, student: student_params }
+            patch :update, params: { id: @student.id, student: student_params }
           end
           context "abcに更新されないこと" do
             it "not updated to abc" do
-              expect(@another_student.reload.name).to_not eq "abc"
+              expect(@student.reload.name).to_not eq "abc"
             end
           end
           context "正常にレスポンスを返さないこと" do
@@ -484,14 +482,14 @@ RSpec.describe StudentsController, type: :controller do
       context "セラピスト養成コースの受講生としてログインしたとき" do
         context "as a therapist training course student" do
           before do
-            student = FactoryBot.create(:student)
-            sign_in student
-            @another_student = FactoryBot.create(:student)
+            login_student = FactoryBot.create(:student)
+            sign_in login_student
+            @student = FactoryBot.create(:student)
           end
           context "削除できないこと" do
             it "does not delete student" do
               expect {
-                delete :destroy, params: { id: @another_student.id }
+                delete :destroy, params: { id: @student.id }
               }.to_not change(Student, :count)
             end
           end
@@ -500,14 +498,14 @@ RSpec.describe StudentsController, type: :controller do
       context "セルフケアコースの受講生としてログインしたとき" do
         context "as a self care coure student" do
           before do
-            student = FactoryBot.create(:student, :self_care)
-            sign_in student
-            @another_student = FactoryBot.create(:student)
+            login_student = FactoryBot.create(:student, :self_care)
+            sign_in login_student
+            @student = FactoryBot.create(:student)
           end
           context "削除できないこと" do
             it "does not delete student" do
               expect {
-                delete :destroy, params: { id: @another_student.id }
+                delete :destroy, params: { id: @student.id }
               }.to_not change(Student, :count)
             end
           end

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe StudentsController, type: :controller do
         end
       end
 
-      context "受講生としてログインしたとき" do
-        context "as a student" do
+      context "セラピスト養成コースの受講生としてログインしたとき" do
+        context "as a therapist training course student" do
           before do
             student = FactoryBot.create(:student)
             sign_in student
@@ -73,6 +73,36 @@ RSpec.describe StudentsController, type: :controller do
               expect(response).to have_http_status "302"
             end
           end
+
+      context "セルフケアコースの受講生としてログインしたとき" do
+        context "as a self care coure student" do
+          before do
+            student = FactoryBot.create(:student, :self_care)
+            sign_in student
+            get :index
+          end
+
+          context "正常にレスポンスを返さないこと" do
+            it "responds not successfully" do
+              expect(response).not_to be_successful
+            end
+          end
+
+          context "302レスポンスを返すこと" do
+            it "returns a 302 response" do
+              expect(response).to have_http_status "302"
+            end
+          end
+
+          context "ルート画面にリダイレクトすること" do
+            it "redirects to the root page" do
+              expect(response).to redirect_to root_path
+            end
+          end
+        end
+      end
+
+
 
           context "ルート画面にリダイレクトすること" do
             it "redirects to the root page" do
@@ -163,8 +193,8 @@ RSpec.describe StudentsController, type: :controller do
         end
       end
 
-      context "受講生としてログインしたとき" do
-        context "as a student" do
+      context "セラピスト養成コースの受講生としてログインしたとき" do
+        context "as a therapist training course student" do
           before do
             student = FactoryBot.create(:student)
             sign_in student
@@ -183,6 +213,37 @@ RSpec.describe StudentsController, type: :controller do
               expect(response).to have_http_status "302"
             end
           end
+
+      context "セルフケアコースの受講生としてログインしたとき" do
+        context "as a self care course student" do
+          before do
+            student = FactoryBot.create(:student, :self_care)
+            sign_in student
+            another_student = FactoryBot.create(:student)
+            get :show, params: { id: another_student.id }
+          end
+
+          context "正常にレスポンスを返さないこと" do
+            it "responds not successfully" do
+              expect(response).not_to be_successful
+            end
+          end
+
+          context "302レスポンスを返すこと" do
+            it "returns a 302 response" do
+              expect(response).to have_http_status "302"
+            end
+          end
+
+          context "ルート画面にリダイレクトすること" do
+            it "redirects to the root page" do
+              expect(response).to redirect_to root_path
+            end
+          end
+        end
+      end
+
+
 
           context "ルート画面にリダイレクトすること" do
             it "redirects to the root page" do
@@ -287,8 +348,8 @@ RSpec.describe StudentsController, type: :controller do
         end
       end
 
-      context "受講生としてログインしたとき" do
-        context "as a student" do
+      context "セラピスト養成コースの受講生としてログインしたとき" do
+        context "as a therapist training course student" do
           before do
             student = FactoryBot.create(:student)
             sign_in student
@@ -318,6 +379,40 @@ RSpec.describe StudentsController, type: :controller do
           end
         end
       end
+
+      context "セルフケアコースの受講生としてログインしたとき" do
+        context "as a self care course student" do
+          before do
+            student = FactoryBot.create(:student, :self_care)
+            sign_in student
+            @another_student = FactoryBot.create(:student)
+            student_params = FactoryBot.attributes_for(:student, name: "abc")
+            patch :update, params: { id: @another_student.id, student: student_params }
+          end
+          context "abcに更新されないこと" do
+            it "not updated to abc" do
+              expect(@another_student.reload.name).to_not eq "abc"
+            end
+          end
+          context "正常にレスポンスを返さないこと" do
+            it "responds not successfully" do
+              expect(response).not_to be_successful
+            end
+          end
+          context "302レスポンスを返すこと" do
+            it "returns a 302 response" do
+              expect(response).to have_http_status "302"
+            end
+          end
+          context "ルート画面にリダイレクトすること" do
+            it "redirects to the root page" do
+              expect(response).to redirect_to root_path
+            end
+          end
+        end
+      end
+
+
 
       context "ゲストとして" do
         context "as a guest" do
@@ -386,8 +481,8 @@ RSpec.describe StudentsController, type: :controller do
           end
         end
       end
-      context "受講生としてログインしたとき" do
-        context "as a student" do
+      context "セラピスト養成コースの受講生としてログインしたとき" do
+        context "as a therapist training course student" do
           before do
             student = FactoryBot.create(:student)
             sign_in student
@@ -402,6 +497,23 @@ RSpec.describe StudentsController, type: :controller do
           end
         end
       end
+      context "セルフケアコースの受講生としてログインしたとき" do
+        context "as a self care coure student" do
+          before do
+            student = FactoryBot.create(:student, :self_care)
+            sign_in student
+            @another_student = FactoryBot.create(:student)
+          end
+          context "削除できないこと" do
+            it "does not delete student" do
+              expect {
+                delete :destroy, params: { id: @another_student.id }
+              }.to_not change(Student, :count)
+            end
+          end
+        end
+      end
+ 
       context "ゲストとして" do
         context "as a guest" do
           before do

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe StudentsController, type: :controller do
             sign_in admin
             get :index
           end
-
           context "正常にレスポンスを返すこと" do
             it "responds successfully" do
               expect(response).to be_successful
@@ -20,6 +19,11 @@ RSpec.describe StudentsController, type: :controller do
             it "returns a 200 response" do
               expect(response).to have_http_status "200"
             end
+          end
+        end
+        context "ルート画面にリダイレクトされないこと" do
+          it "does not redirect to root page" do
+            expect(response).to_not redirect_to "/"
           end
         end
       end
@@ -33,21 +37,18 @@ RSpec.describe StudentsController, type: :controller do
             sign_in staff
             get :index
           end
-
           context "正常にレスポンスを返さないこと" do
             it "responds not successfully" do
               expect(response).not_to be_successful
             end
           end
-
           context "302レスポンスを返すこと" do
             it "returns a 302 response" do
               expect(response).to have_http_status "302"
             end
           end
-
           context "ルート画面にリダイレクトすること" do
-            it "redirects to the root page" do
+            it "redirects to root page" do
               expect(response).to redirect_to "/"
             end
           end
@@ -61,21 +62,18 @@ RSpec.describe StudentsController, type: :controller do
             sign_in student
             get :index
           end
-
           context "正常にレスポンスを返さないこと" do
             it "responds not successfully" do
               expect(response).not_to be_successful
             end
           end
-
           context "302レスポンスを返すこと" do
             it "returns a 302 response" do
               expect(response).to have_http_status "302"
             end
           end
-
           context "ルート画面にリダイレクトすること" do
-            it "redirects to the root page" do
+            it "redirects to root page" do
               expect(response).to redirect_to "/"
             end
           end
@@ -89,25 +87,21 @@ RSpec.describe StudentsController, type: :controller do
             sign_in student
             get :index
           end
-
           context "正常にレスポンスを返さないこと" do
             it "responds not successfully" do
               expect(response).not_to be_successful
             end
           end
-
           context "302レスポンスを返すこと" do
             it "returns a 302 response" do
               expect(response).to have_http_status "302"
             end
           end
-
           context "ルート画面にリダイレクトすること" do
-            it "redirects to the root page" do
+            it "redirects to root page" do
               expect(response).to redirect_to root_path
             end
           end
-
         end
       end
 
@@ -121,15 +115,13 @@ RSpec.describe StudentsController, type: :controller do
               expect(response).not_to be_successful
             end
           end
-
           context "302レスポンスを返すこと" do
             it "returns a 302 response" do
               expect(response).to have_http_status "302"
             end
           end
-
           context "ルート画面にリダイレクトすること" do
-            it "redirects to the root page" do
+            it "redirects to root page" do
               expect(response).to redirect_to root_path
             end
           end
@@ -137,6 +129,7 @@ RSpec.describe StudentsController, type: :controller do
       end
     end
   end
+
   describe "#show" do
     context "正常系" do
       context "管理者としてログインしたとき" do
@@ -147,7 +140,6 @@ RSpec.describe StudentsController, type: :controller do
             student = FactoryBot.create(:student)
             get :show, params: { id: student.id }
           end
-
           context "正常にレスポンスを返すこと" do
             it "responds successfully" do
               expect(response).to be_successful
@@ -156,6 +148,11 @@ RSpec.describe StudentsController, type: :controller do
           context "200レスポンスを返すこと" do
             it "returns a 200 response" do
               expect(response).to have_http_status "200"
+            end
+          end
+          context "ルート画面にリダイレクトされないこと" do
+            it "does not redirect to root page" do
+              expect(response).to_not redirect_to "/"
             end
           end
         end
@@ -171,21 +168,18 @@ RSpec.describe StudentsController, type: :controller do
             student = FactoryBot.create(:student)
             get :show, params: { id: student.id }
           end
-
           context "正常にレスポンスを返さないこと" do
             it "responds not successfully" do
               expect(response).not_to be_successful
             end
           end
-
           context "302レスポンスを返すこと" do
             it "returns a 302 response" do
               expect(response).to have_http_status "302"
             end
           end
-
           context "ルート画面にリダイレクトすること" do
-            it "redirects to the root page" do
+            it "redirects to root page" do
               expect(response).to redirect_to "/"
             end
           end
@@ -200,21 +194,18 @@ RSpec.describe StudentsController, type: :controller do
             student = FactoryBot.create(:student)
             get :show, params: { id: student.id }
           end
-
           context "正常にレスポンスを返さないこと" do
             it "responds not successfully" do
               expect(response).not_to be_successful
             end
           end
-
           context "302レスポンスを返すこと" do
             it "returns a 302 response" do
               expect(response).to have_http_status "302"
             end
           end
-
           context "ルート画面にリダイレクトすること" do
-            it "redirects to the root page" do
+            it "redirects to root page" do
               expect(response).to redirect_to root_path
             end
           end
@@ -229,26 +220,22 @@ RSpec.describe StudentsController, type: :controller do
             student = FactoryBot.create(:student)
             get :show, params: { id: student.id }
           end
-
           context "正常にレスポンスを返さないこと" do
             it "responds not successfully" do
               expect(response).not_to be_successful
             end
           end
-
           context "302レスポンスを返すこと" do
             it "returns a 302 response" do
               expect(response).to have_http_status "302"
             end
           end
-
           context "ルート画面にリダイレクトすること" do
-            it "redirects to the root page" do
+            it "redirects to root page" do
               expect(response).to redirect_to root_path
             end
           end
-
-       end
+        end
       end
 
       context "ゲストとして" do
@@ -262,15 +249,13 @@ RSpec.describe StudentsController, type: :controller do
               expect(response).not_to be_successful
             end
           end
-
           context "302レスポンスを返すこと" do
             it "returns a 302 response" do
               expect(response).to have_http_status "302"
             end
           end
-
           context "ルート画面にリダイレクトすること" do
-            it "redirects to the root page" do
+            it "redirects to root page" do
               expect(response).to redirect_to root_path
             end
           end
@@ -278,6 +263,7 @@ RSpec.describe StudentsController, type: :controller do
       end
     end
   end
+
   describe "#update" do
     context "正常系" do
       context "管理者としてログインしたとき" do
@@ -290,7 +276,7 @@ RSpec.describe StudentsController, type: :controller do
             patch :update, params: { id: @student.id, student: student_params }
           end
           context "abcに更新されること" do
-            it "responds successfully" do
+            it "updated to abc" do
               expect(@student.reload.name).to eq "abc"
             end
           end
@@ -305,7 +291,7 @@ RSpec.describe StudentsController, type: :controller do
             end
           end
           context "ルート画面にリダイレクトされないこと" do
-            it "redirects to the root page" do
+            it "does not redirect to root page" do
               expect(response).to_not redirect_to "/"
             end
           end
@@ -339,7 +325,7 @@ RSpec.describe StudentsController, type: :controller do
             end
           end
           context "ルート画面にリダイレクトすること" do
-            it "redirects to the root page" do
+            it "redirects to root page" do
               expect(response).to redirect_to "/"
             end
           end
@@ -371,7 +357,7 @@ RSpec.describe StudentsController, type: :controller do
             end
           end
           context "ルート画面にリダイレクトすること" do
-            it "redirects to the root page" do
+            it "redirects to root page" do
               expect(response).to redirect_to root_path
             end
           end
@@ -403,14 +389,12 @@ RSpec.describe StudentsController, type: :controller do
             end
           end
           context "ルート画面にリダイレクトすること" do
-            it "redirects to the root page" do
+            it "redirects to root page" do
               expect(response).to redirect_to root_path
             end
           end
         end
       end
-
-
 
       context "ゲストとして" do
         context "as a guest" do
@@ -435,7 +419,7 @@ RSpec.describe StudentsController, type: :controller do
             end
           end
           context "ルート画面にリダイレクトすること" do
-            it "redirects to the root page" do
+            it "redirects to root page" do
               expect(response).to redirect_to root_path
             end
           end
@@ -443,6 +427,7 @@ RSpec.describe StudentsController, type: :controller do
       end
     end
   end
+
   describe "#destroy" do
     context "正常系" do
       context "管理者としてログインしたとき" do
@@ -452,11 +437,15 @@ RSpec.describe StudentsController, type: :controller do
             sign_in admin
             @student = FactoryBot.create(:student)
           end
-          context "削除されること" do
-            it "admin deletes student" do
+          context "削除されること、students画面にリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+            it "admin deletes student and redirect to students page and returns a 200 response and does not redirect to root page" do
               expect {
                 delete :destroy, params: { id: @student.id }
               }.to change(Student, :count).by(-1)
+              #expect(response).to be_successful
+              expect(response).to redirect_to students_path
+              expect(response).to have_http_status "302"
+              expect(response).to_not redirect_to "/"
             end
           end
         end
@@ -470,11 +459,14 @@ RSpec.describe StudentsController, type: :controller do
             sign_in staff
             @student = FactoryBot.create(:student)
           end
-          context "削除できないこと" do
-            it "does not delelt student" do
+          context "削除できないこと、正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+            it "does not delelt student and responds not successfully and returns a 302 response and redirects to root page" do
               expect {
                 delete :destroy, params: { id: @student.id }
               }.to_not change(Student, :count)
+              expect(response).not_to be_successful
+              expect(response).to have_http_status "302"
+              expect(response).to redirect_to "/"
             end
           end
         end
@@ -486,11 +478,14 @@ RSpec.describe StudentsController, type: :controller do
             sign_in login_student
             @student = FactoryBot.create(:student)
           end
-          context "削除できないこと" do
-            it "does not delete student" do
+          context "削除できないこと、正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+            it "does not delelt student and responds not successfully and returns a 302 response and redirects to root page" do
               expect {
                 delete :destroy, params: { id: @student.id }
               }.to_not change(Student, :count)
+              expect(response).not_to be_successful
+              expect(response).to have_http_status "302"
+              expect(response).to redirect_to "/"
             end
           end
         end
@@ -502,26 +497,32 @@ RSpec.describe StudentsController, type: :controller do
             sign_in login_student
             @student = FactoryBot.create(:student)
           end
-          context "削除できないこと" do
-            it "does not delete student" do
+          context "削除できないこと、正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+            it "does not delelt student and responds not successfully and returns a 302 response and redirects to root page" do
               expect {
                 delete :destroy, params: { id: @student.id }
               }.to_not change(Student, :count)
+              expect(response).not_to be_successful
+              expect(response).to have_http_status "302"
+              expect(response).to redirect_to "/"
             end
           end
         end
       end
- 
+
       context "ゲストとして" do
         context "as a guest" do
           before do
             @student = FactoryBot.create(:student)
           end
-          context "削除できないこと" do
-            it "does not delete student" do
+          context "削除できないこと、正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+            it "does not delelt student and responds not successfully and returns a 302 response and redirects to root page" do
               expect {
                 delete :destroy, params: { id: @student.id }
               }.to_not change(Student, :count)
+              expect(response).not_to be_successful
+              expect(response).to have_http_status "302"
+              expect(response).to redirect_to "/"
             end
           end
         end

--- a/spec/factories/blogs.rb
+++ b/spec/factories/blogs.rb
@@ -2,12 +2,14 @@ FactoryBot.define do
   factory :blog do
     sequence(:title)    { |n| "title#{n}" }
     sequence(:datetime) { |n|  DateTime.current + ((n-1)%5).day }
+    #staff               { FactoryBot.create(:staff) }
     staff
     image               { Rack::Test::UploadedFile.new(File.join(Rails.root, "public/uploads/blog/image/1/something1.jpg")) }
     share_with          { "staff" }
 
     trait :admin do
       staff          { FactoryBot.create(:staff, :admin) }
+      #association :staff, factory: :admin
       image          { Rack::Test::UploadedFile.new(File.join(Rails.root, "public/uploads/blog/image/2/something2.jpg")) }
     end
 

--- a/spec/requests/admins_spec.rb
+++ b/spec/requests/admins_spec.rb
@@ -1,0 +1,133 @@
+require 'rails_helper'
+
+RSpec.describe "Admins", type: :request do
+  describe "#student_edit" do
+    context "正常系" do
+      context "管理者としてログインしたとき" do
+        context "as admin" do
+          before do
+            admin = FactoryBot.create(:staff, :admin)
+            sign_in admin
+            student = FactoryBot.create(:student, :sample)
+            get student_edit_admin_path student.id
+          end
+          context "正常にレスポンスを返すこと" do
+            it "responds successfully" do
+              expect(response).to be_successful
+            end
+          end
+          context "200レスポンスを返すこと" do
+            it "returns a 200 response" do
+              expect(response).to have_http_status "200"
+            end
+          end
+        end
+      end
+    end
+    context "異常系" do
+
+      context "スタッフとしてログインしたとき" do
+        context "as a staff" do
+          before do
+            staff = FactoryBot.create(:staff)
+            sign_in staff
+            student = FactoryBot.create(:student, :sample)
+            get student_edit_admin_path student.id
+          end
+          context "正常にレスポンスを返さないこと" do
+            it "responds not successfully" do
+              expect(response).not_to be_successful
+            end
+          end
+          context "302レスポンスを返すこと" do
+            it "returns a 302 response" do
+              expect(response).to have_http_status "302"
+            end
+          end
+          context "ルート画面にリダイレクトすること" do
+            it "redirects to the root page" do
+              expect(response).to redirect_to "/"
+            end
+          end
+        end
+      end
+
+      context "セラピスト養成コースの受講生としてログインしたとき" do
+        context "as a therapist training course student" do
+          before do
+            student = FactoryBot.create(:student)
+            sign_in student
+            student = FactoryBot.create(:student, :sample)
+            get student_edit_admin_path student.id
+          end
+          context "正常にレスポンスを返さないこと" do
+            it "responds not successfully" do
+              expect(response).not_to be_successful
+            end
+          end
+          context "302レスポンスを返すこと" do
+            it "returns a 302 response" do
+              expect(response).to have_http_status "302"
+            end
+          end
+          context "ルート画面にリダイレクトすること" do
+            it "redirects to the root page" do
+              expect(response).to redirect_to root_path
+            end
+          end
+        end
+      end
+
+      context "セルフケアコースの受講生としてログインしたとき" do
+        context "as a self care course student" do
+          before do
+            student = FactoryBot.create(:student, :self_care)
+            sign_in student
+            student = FactoryBot.create(:student, :sample)
+            get student_edit_admin_path student.id
+          end
+          context "正常にレスポンスを返さないこと" do
+            it "responds not successfully" do
+              expect(response).not_to be_successful
+            end
+          end
+          context "302レスポンスを返すこと" do
+            it "returns a 302 response" do
+              expect(response).to have_http_status "302"
+            end
+          end
+          context "ルート画面にリダイレクトすること" do
+            it "redirects to the root page" do
+              expect(response).to redirect_to root_path
+            end
+          end
+        end
+      end
+
+
+      context "ゲストとして" do
+        context "as a guest" do
+          before do
+            student = FactoryBot.create(:student, :sample)
+            get student_edit_admin_path student.id
+          end
+          context "正常にレスポンスを返さないこと" do
+            it "responds not successfully" do
+              expect(response).not_to be_successful
+            end
+          end
+          context "302レスポンスを返すこと" do
+            it "returns a 302 response" do
+              expect(response).to have_http_status "302"
+            end
+          end
+          context "ルート画面にリダイレクトすること" do
+            it "redirects to the root page" do
+              expect(response).to redirect_to root_path
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/blogs_spec.rb
+++ b/spec/requests/blogs_spec.rb
@@ -1,0 +1,1001 @@
+require 'rails_helper'
+
+RSpec.describe "Blogs", type: :request do
+  describe "#new" do
+    context "正常系" do
+      context "管理者は管理者自身のブログにnewでアクセス" do
+        before do
+          admin = FactoryBot.create(:staff, :admin)
+          sign_in admin
+          get new_staff_blog_path admin.id
+        end
+        context "正常にレスポンスを返すこと、200レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "responds successfully and returns a 200 response" do
+            expect(response).to be_successful
+            expect(response).to have_http_status "200"
+            expect(response).to_not redirect_to "/"
+          end
+        end
+      end
+
+      context "管理者はスタッフのブログにnewでアクセス" do
+        before do
+          staff = FactoryBot.create(:staff)
+          admin = FactoryBot.create(:staff, :admin)
+          sign_in admin
+          get new_staff_blog_path staff.id
+        end
+        context "正常にレスポンスを返すこと、200レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "responds successfully and returns a 200 response" do
+            expect(response).to be_successful
+            expect(response).to have_http_status "200"
+            expect(response).to_not redirect_to "/"
+          end
+        end
+      end
+
+      context "スタッフはスタッフ自身のブログにnewでアクセス" do
+        before do
+          staff = FactoryBot.create(:staff)
+          sign_in staff
+          get new_staff_blog_path staff.id
+        end
+        context "正常にレスポンスを返すこと、200レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "responds successfully and returns a 200 response" do
+            expect(response).to be_successful
+            expect(response).to have_http_status "200"
+            expect(response).to_not redirect_to "/"
+          end
+        end
+      end
+    end
+
+    context "異常系" do
+      context "スタッフは管理者のブログにnewでアクセス" do
+        before do
+          admin = FactoryBot.create(:staff, :admin)
+          staff = FactoryBot.create(:staff)
+          sign_in staff
+          get new_staff_blog_path admin.id
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "スタッフは別のスタッフのブログにnewでアクセス" do
+        before do
+          staff = FactoryBot.create(:staff)
+          login_staff = FactoryBot.create(:staff)
+          sign_in login_staff
+          get new_staff_blog_path staff.id
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "セラピスト養成コースの受講生は管理者のブログにnewでアクセス" do
+        before do
+          admin = FactoryBot.create(:staff, :admin)
+          student = FactoryBot.create(:student)
+          sign_in student
+          get new_staff_blog_path admin.id
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "セラピスト養成コースの受講生はスタッフのブログにnewでアクセス" do
+        before do
+          staff = FactoryBot.create(:staff)
+          student = FactoryBot.create(:student)
+          sign_in student
+          get new_staff_blog_path staff.id
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "セルフケアコースの受講生は管理者のブログにnewでアクセス" do
+        before do
+          admin = FactoryBot.create(:staff, :admin)
+          student = FactoryBot.create(:student, :self_care)
+          sign_in student
+          get new_staff_blog_path admin.id
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "セルフケアコースの受講生はスタッフのブログにnewでアクセス" do
+        before do
+          staff = FactoryBot.create(:staff)
+          student = FactoryBot.create(:student, :self_care)
+          sign_in student
+          get new_staff_blog_path staff.id
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "ゲストは管理者のブログにnewでアクセス" do
+        before do
+          admin = FactoryBot.create(:staff, :admin)
+          get new_staff_blog_path admin.id
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "ゲストはスタッフのブログにnewでアクセス" do
+        before do
+          staff = FactoryBot.create(:staff)
+          get new_staff_blog_path staff.id
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+    end
+  end
+
+  describe "#create" do
+    context "正常系" do
+      context "管理者は管理者自身のブログにcreateでアクセス" do
+        before do
+          @admin = FactoryBot.create(:staff, :admin)
+          sign_in @admin
+        end
+        context "正常にレスポンスを返すこと、200レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "responds successfully and returns a 200 response and not redirected to root page" do
+            #admin_blog_params = FactoryBot.attributes_for(:blog, staff: @admin)
+            #admin_blog_params = FactoryBot.attributes_for(:blog, owner: @admin)
+            #admin_blog_params = FactoryBot.attributes_for(:blog, :admin, title: "New Blog title")
+            admin_blog_params = FactoryBot.attributes_for(:blog, :admin)
+            #admin =  Staff.find(admin_blog_params[:staff].id)
+            #puts admin.name
+            #sign_in admin
+            expect {
+              post staff_blogs_path @admin.id, params: { blog: admin_blog_params }
+            }.to change(@admin.blogs, :count).by(0)
+            #}.to change(Blog, :count).by(0)
+            expect(response).to be_successful
+            expect(response).to have_http_status "200"
+            expect(response).to_not redirect_to "/"
+          end
+        end
+      end
+      context "管理者はスタッフのブログにcreateでアクセス" do
+        before do
+          @admin = FactoryBot.create(:staff, :admin)
+          sign_in @admin
+          @staff = FactoryBot.create(:staff)
+        end
+        context "正常にレスポンスを返すこと、200レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "responds successfully and returns a 200 response and not redirected to root page" do
+            blog_params = FactoryBot.attributes_for(:blog)
+            expect {
+              post staff_blogs_path @staff.id, params: { blog: blog_params }
+            }.to change(@staff.blogs, :count).by(0)
+            expect(response).to be_successful
+            expect(response).to have_http_status "200"
+            expect(response).to_not redirect_to "/"
+          end
+        end
+      end
+
+      context "スタッフは自分自身ののブログにcreateでアクセス" do
+        before do
+          @staff = FactoryBot.create(:staff)
+          sign_in @staff
+        end
+        context "正常にレスポンスを返すこと、200レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "responds successfully and returns a 200 response and not redirected to root page" do
+            blog_params = FactoryBot.attributes_for(:blog)
+            expect {
+              post staff_blogs_path @staff.id, params: { blog: blog_params }
+            }.to change(@staff.blogs, :count).by(0)
+            expect(response).to be_successful
+            expect(response).to have_http_status "200"
+            expect(response).to_not redirect_to "/"
+          end
+        end
+      end
+    end
+
+    context "異常系" do
+      context "スタッフは管理者のブログにcreateでアクセス" do
+        before do
+          staff = FactoryBot.create(:staff)
+          sign_in staff
+          @admin = FactoryBot.create(:staff, :admin)
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            admin_blog_params = FactoryBot.attributes_for(:blog, :admin)
+            expect {
+              post staff_blogs_path @admin.id, params: { blog: admin_blog_params }
+            }.to change(@admin.blogs, :count).by(0)
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "スタッフは別のスタッフのブログにcreateでアクセス" do
+        before do
+          login_staff = FactoryBot.create(:staff)
+          sign_in login_staff
+          @staff = FactoryBot.create(:staff)
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            blog_params = FactoryBot.attributes_for(:blog)
+            expect {
+              post staff_blogs_path @staff.id, params: { blog: blog_params }
+            }.to change(@staff.blogs, :count).by(0)
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+     context "セラピスト養成コースの受講生は管理者のブログにcreateでアクセス" do
+        before do
+          student = FactoryBot.create(:student)
+          sign_in student
+          @admin = FactoryBot.create(:staff, :admin)
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            admin_blog_params = FactoryBot.attributes_for(:blog, :admin)
+            expect {
+              post staff_blogs_path @admin.id, params: { blog: admin_blog_params }
+            }.to change(@admin.blogs, :count).by(0)
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+     context "セラピスト養成コースの受講生はスタッフのブログにcreateでアクセス" do
+        before do
+          student = FactoryBot.create(:student)
+          sign_in student
+          @staff = FactoryBot.create(:staff)
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            blog_params = FactoryBot.attributes_for(:blog)
+            expect {
+              post staff_blogs_path @staff.id, params: { blog: blog_params }
+            }.to change(@staff.blogs, :count).by(0)
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+     context "セルフケアコースの受講生は管理者のブログにcreateでアクセス" do
+        before do
+          student = FactoryBot.create(:student, :self_care)
+          sign_in student
+          @admin = FactoryBot.create(:staff, :admin)
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            admin_blog_params = FactoryBot.attributes_for(:blog, :admin)
+            expect {
+              post staff_blogs_path @admin.id, params: { blog: admin_blog_params }
+            }.to change(@admin.blogs, :count).by(0)
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+     context "セルフケアコースの受講生はスタッフのブログにcreateでアクセス" do
+        before do
+          student = FactoryBot.create(:student, :self_care)
+          sign_in student
+          @staff = FactoryBot.create(:staff)
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            blog_params = FactoryBot.attributes_for(:blog)
+            expect {
+              post staff_blogs_path @staff.id, params: { blog: blog_params }
+            }.to change(@staff.blogs, :count).by(0)
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+     context "ゲストは管理者のブログにcreateでアクセス" do
+        before do
+          @admin = FactoryBot.create(:staff, :admin)
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            admin_blog_params = FactoryBot.attributes_for(:blog, :admin)
+            expect {
+              post staff_blogs_path @admin.id, params: { blog: admin_blog_params }
+            }.to change(@admin.blogs, :count).by(0)
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+     context "ゲストはスタッフのブログにcreateでアクセス" do
+        before do
+          @staff = FactoryBot.create(:staff)
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            blog_params = FactoryBot.attributes_for(:blog)
+            expect {
+              post staff_blogs_path @staff.id, params: { blog: blog_params }
+            }.to change(@staff.blogs, :count).by(0)
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+    end
+  end
+
+  describe "#edit" do
+    context "正常系" do
+      context "管理者は管理者自身のブログにeditでアクセス" do
+        before do
+          admin_blog = FactoryBot.create(:blog, :admin)
+          admin = Staff.find(admin_blog.staff_id)
+          sign_in admin
+          get edit_staff_blog_path admin.id, admin_blog.id
+        end
+        context "正常にレスポンスを返すこと、200レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "responds successfully and returns a 200 response" do
+            expect(response).to be_successful
+            expect(response).to have_http_status "200"
+            expect(response).to_not redirect_to "/"
+          end
+        end
+      end
+
+      context "管理者はスタッフのブログにeditでアクセス" do
+        before do
+          staff_blog = FactoryBot.create(:blog)
+          staff = Staff.find(staff_blog.staff_id)
+          admin = FactoryBot.create(:staff, :admin)
+          sign_in admin
+          get edit_staff_blog_path staff.id, staff_blog.id
+        end
+        context "正常にレスポンスを返すこと、200レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "responds successfully and returns a 200 response" do
+           expect(response).to be_successful
+           expect(response).to have_http_status "200"
+           expect(response).to_not redirect_to "/"
+          end
+        end
+      end
+
+      context "スタッフは自分自身のブログにeditでアクセス" do
+        before do
+          staff_blog = FactoryBot.create(:blog)
+          staff = Staff.find(staff_blog.staff_id)
+          sign_in staff
+          get edit_staff_blog_path staff.id, staff_blog.id
+        end
+        context "正常にレスポンスを返すこと、200レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "responds successfully and returns a 200 response" do
+            expect(response).to be_successful
+            expect(response).to have_http_status "200"
+            expect(response).to_not redirect_to "/"
+          end
+        end
+      end
+
+    end
+
+    context "異常系" do
+       context "スタッフは管理者のブログにeditでアクセス" do
+        before do
+          admin_blog = FactoryBot.create(:blog, :admin)
+          admin = Staff.find(admin_blog.staff_id)
+          staff = FactoryBot.create(:staff)
+          sign_in staff
+          get edit_staff_blog_path admin.id, admin_blog.id
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "スタッフは他のスタッフのブログにeditでアクセス" do
+        before do
+          staff_blog = FactoryBot.create(:blog)
+          staff = Staff.find(staff_blog.staff_id)
+          login_staff = FactoryBot.create(:staff)
+          sign_in login_staff
+          get edit_staff_blog_path staff.id, staff_blog.id
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "セラピスト養成コースの受講生は管理者のブログにeditでアクセス" do
+        before do
+          admin_blog = FactoryBot.create(:blog, :admin)
+          admin = Staff.find(admin_blog.staff_id)
+          student = FactoryBot.create(:student)
+          sign_in student
+          get edit_staff_blog_path admin.id, admin_blog.id
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "セラピスト養成コースの受講生はスタッフのブログにeditでアクセス" do
+        before do
+          staff_blog = FactoryBot.create(:blog)
+          staff = Staff.find(staff_blog.staff_id)
+          student = FactoryBot.create(:student)
+          sign_in student
+          get edit_staff_blog_path staff.id, staff_blog.id
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "セルフケアコースの受講生は管理者のブログにeditでアクセス" do
+        before do
+          admin_blog = FactoryBot.create(:blog, :admin)
+          admin = Staff.find(admin_blog.staff_id)
+          student = FactoryBot.create(:student, :self_care)
+          sign_in student
+          get edit_staff_blog_path admin.id, admin_blog.id
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "セルフケアコースの受講生はスタッフのブログにeditでアクセス" do
+        before do
+          staff_blog = FactoryBot.create(:blog)
+          staff = Staff.find(staff_blog.staff_id)
+          student = FactoryBot.create(:student, :self_care)
+          sign_in student
+          get edit_staff_blog_path staff.id, staff_blog.id
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "ゲストは管理者のブログにeditでアクセス" do
+        before do
+          admin_blog = FactoryBot.create(:blog, :admin)
+          admin = Staff.find(admin_blog.staff_id)
+          get edit_staff_blog_path admin.id, admin_blog.id
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "ゲストはスタッフのブログにeditでアクセス" do
+        before do
+          staff_blog = FactoryBot.create(:blog)
+          staff = Staff.find(staff_blog.staff_id)
+          get edit_staff_blog_path staff.id, staff_blog.id
+        end
+        context "正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+          it "responds not successfully and returns a 302 response and redirects to root page" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+    end
+  end
+
+  describe "#update" do
+    context "正常系" do
+      context "管理者は管理者自身のブログにupdateでアクセス" do
+        before do
+          @admin_blog = FactoryBot.create(:blog, :admin)
+          admin = Staff.find(@admin_blog.staff_id)
+          sign_in admin
+          blogs_params = FactoryBot.attributes_for(:blog, title: "New Blog Name")
+          patch staff_blog_path admin.id, @admin_blog.id, params: { blog: blogs_params }
+        end
+        context "New Blog Nameに更新されること、詳細ページへリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "updated to New Blog Name and redirects to show page and returns 302 response and not redirected to root page" do
+            expect(@admin_blog.reload.title).to eq "New Blog Name"
+            expect(response).to redirect_to staff_blog_path
+            expect(response).to have_http_status "302"
+            expect(response).to_not redirect_to "/"
+          end
+        end
+      end
+
+      context "管理者はスタッフのブログにupdateでアクセス" do
+        before do
+          @staff_blog = FactoryBot.create(:blog)
+          staff = Staff.find(@staff_blog.staff_id)
+          admin = FactoryBot.create(:staff, :admin)
+          sign_in admin
+          blogs_params = FactoryBot.attributes_for(:blog, title: "New Blog Name")
+          patch staff_blog_path staff.id, @staff_blog.id, params: { blog: blogs_params }
+        end
+        context "New Blog Nameに更新されること、詳細ページへリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "updated to New Blog Name and redirects to show page and returns 302 response and not redirected to root page" do
+            expect(@staff_blog.reload.title).to eq "New Blog Name"
+            expect(response).to redirect_to staff_blog_path
+            expect(response).to have_http_status "302"
+            expect(response).to_not redirect_to "/"
+          end
+        end
+      end
+
+      context "スタッフは自分自身のブログにupdateでアクセス" do
+        before do
+          @staff_blog = FactoryBot.create(:blog)
+          staff = Staff.find(@staff_blog.staff_id)
+          sign_in staff
+          blogs_params = FactoryBot.attributes_for(:blog, title: "New Blog Name")
+          patch staff_blog_path staff.id, @staff_blog.id, params: { blog: blogs_params }
+        end
+        context "New Blog Nameに更新されること、詳細ページへリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "updated to New Blog Name and redirects to show page and returns 302 response and not redirected to root page" do
+            expect(@staff_blog.reload.title).to eq "New Blog Name"
+            expect(response).to redirect_to staff_blog_path
+            expect(response).to have_http_status "302"
+            expect(response).to_not redirect_to "/"
+          end
+        end
+      end
+    end
+
+    context "異常系" do
+
+       context "スタッフは管理者のブログにupdateでアクセス" do
+        before do
+          @admin_blog = FactoryBot.create(:blog, :admin)
+          admin = Staff.find(@admin_blog.staff_id)
+          staff = FactoryBot.create(:staff)
+          sign_in staff
+          blogs_params = FactoryBot.attributes_for(:blog, title: "New Blog Name")
+          patch staff_blog_path admin.id, @admin_blog.id, params: { blog: blogs_params }
+        end
+        context "New Blog Nameに更新されないこと、正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトされること" do
+          it "not updated to New Blog Name and responds not successfully and returns a 302 response and redirects to root page" do
+            expect(@admin_blog.reload.title).to_not eq "New Blog Name"
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to root_path
+          end
+        end
+      end
+
+      context "スタッフは他のスタッフのブログにupdateでアクセス" do
+        before do
+          @staff_blog = FactoryBot.create(:blog)
+          staff = Staff.find(@staff_blog.staff_id)
+          login_staff = FactoryBot.create(:staff)
+          sign_in login_staff
+          blogs_params = FactoryBot.attributes_for(:blog, title: "New Blog Name")
+          patch staff_blog_path staff.id, @staff_blog.id, params: { blog: blogs_params }
+        end
+        context "New Blog Nameに更新されないこと、正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトされること" do
+          it "not updated to New Blog Name and responds not successfully and returns a 302 response and redirects to root page" do
+            expect(@staff_blog.reload.title).to_not eq "New Blog Name"
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to root_path
+          end
+        end
+      end
+
+      context "セラピスト養成コースの受講生は管理者のブログにupdateでアクセス" do
+        before do
+          @admin_blog = FactoryBot.create(:blog, :admin)
+          admin = Staff.find(@admin_blog.staff_id)
+          student = FactoryBot.create(:student)
+          sign_in student
+          blogs_params = FactoryBot.attributes_for(:blog, title: "New Blog Name")
+          patch staff_blog_path admin.id, @admin_blog.id, params: { blog: blogs_params }
+        end
+        context "New Blog Nameに更新されないこと、正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトされること" do
+          it "not updated to New Blog Name and responds not successfully and returns a 302 response and redirects to root page" do
+            expect(@admin_blog.reload.title).to_not eq "New Blog Name"
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to root_path
+          end
+        end
+      end
+
+      context "セラピスト養成コースの受講生はスタッフのブログにupdateでアクセス" do
+        before do
+          @staff_blog = FactoryBot.create(:blog)
+          staff = Staff.find(@staff_blog.staff_id)
+          student = FactoryBot.create(:student)
+          sign_in student
+          blogs_params = FactoryBot.attributes_for(:blog, title: "New Blog Name")
+          patch staff_blog_path staff.id, @staff_blog.id, params: { blog: blogs_params }
+        end
+        context "New Blog Nameに更新されないこと、正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトされること" do
+          it "not updated to New Blog Name and responds not successfully and returns a 302 response and redirects to root page" do
+            expect(@staff_blog.reload.title).to_not eq "New Blog Name"
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to root_path
+          end
+        end
+      end
+
+      context "セルフケアコースの受講生は管理者のブログにupdateでアクセス" do
+        before do
+          @admin_blog = FactoryBot.create(:blog, :admin)
+          admin = Staff.find(@admin_blog.staff_id)
+          student = FactoryBot.create(:student, :self_care)
+          sign_in student
+          blogs_params = FactoryBot.attributes_for(:blog, title: "New Blog Name")
+          patch staff_blog_path admin.id, @admin_blog.id, params: { blog: blogs_params }
+        end
+        context "New Blog Nameに更新されないこと、正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトされること" do
+          it "not updated to New Blog Name and responds not successfully and returns a 302 response and redirects to root page" do
+            expect(@admin_blog.reload.title).to_not eq "New Blog Name"
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to root_path
+          end
+        end
+      end
+
+      context "セルフケアコースの受講生はスタッフのブログにupdateでアクセス" do
+        before do
+          @staff_blog = FactoryBot.create(:blog)
+          staff = Staff.find(@staff_blog.staff_id)
+          student = FactoryBot.create(:student, :self_care)
+          sign_in student
+          blogs_params = FactoryBot.attributes_for(:blog, title: "New Blog Name")
+          patch staff_blog_path staff.id, @staff_blog.id, params: { blog: blogs_params }
+        end
+        context "New Blog Nameに更新されないこと、正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトされること" do
+          it "not updated to New Blog Name and responds not successfully and returns a 302 response and redirects to root page" do
+            expect(@staff_blog.reload.title).to_not eq "New Blog Name"
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to root_path
+          end
+        end
+      end
+
+      context "ゲストは管理者のブログにupdateでアクセス" do
+        before do
+          @admin_blog = FactoryBot.create(:blog, :admin)
+          admin = Staff.find(@admin_blog.staff_id)
+          blogs_params = FactoryBot.attributes_for(:blog, title: "New Blog Name")
+          patch staff_blog_path admin.id, @admin_blog.id, params: { blog: blogs_params }
+        end
+        context "New Blog Nameに更新されないこと、正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトされること" do
+          it "not updated to New Blog Name and responds not successfully and returns a 302 response and redirects to root page" do
+            expect(@admin_blog.reload.title).to_not eq "New Blog Name"
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to root_path
+          end
+        end
+      end
+
+      context "ゲストはスタッフのブログにupdateでアクセス" do
+        before do
+          @staff_blog = FactoryBot.create(:blog)
+          staff = Staff.find(@staff_blog.staff_id)
+          blogs_params = FactoryBot.attributes_for(:blog, title: "New Blog Name")
+          patch staff_blog_path staff.id, @staff_blog.id, params: { blog: blogs_params }
+        end
+        context "New Blog Nameに更新されないこと、正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトされること" do
+          it "not updated to New Blog Name and responds not successfully and returns a 302 response and redirects to root page" do
+            expect(@staff_blog.reload.title).to_not eq "New Blog Name"
+            expect(response).to_not be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to root_path
+          end
+        end
+      end
+    end
+  end
+
+  describe "#destroy" do
+    context "正常系" do
+      context "管理者は管理者自身のブログにdeleteでアクセス" do
+        before do
+          @admin_blog = FactoryBot.create(:blog, :admin)
+          @admin = Staff.find(@admin_blog.staff_id)
+          sign_in @admin
+        end
+        context "削除されること、staff_blogs画面にリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "admin deletes blog and redirect to blogs page and returns a 200 response and does not redirect to root page" do
+            expect {
+              delete staff_blog_path @admin.id, @admin_blog.id
+            }.to change(@admin.blogs, :count).by(-1)
+            expect(response).to redirect_to staff_blogs_path
+            expect(response).to have_http_status "302"
+            expect(response).to_not redirect_to "/"
+          end
+        end
+      end
+
+      context "管理者はスタッフのブログにdeleteでアクセス" do
+        before do
+          @staff_blog = FactoryBot.create(:blog, :admin)
+          @staff = Staff.find(@staff_blog.staff_id)
+          admin = FactoryBot.create(:staff, :admin)
+          sign_in admin
+        end
+        context "削除されること、staff_blogs画面にリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "admin deletes blog and redirect to blogs page and returns a 200 response and does not redirect to root page" do
+            expect {
+              delete staff_blog_path @staff.id, @staff_blog.id
+            }.to change(@staff.blogs, :count).by(-1)
+            expect(response).to redirect_to staff_blogs_path
+            expect(response).to have_http_status "302"
+            expect(response).to_not redirect_to "/"
+          end
+        end
+      end
+
+      context "スタッフは自分自身のブログにdeleteでアクセス" do
+        before do
+          @staff_blog = FactoryBot.create(:blog, :admin)
+          @staff = Staff.find(@staff_blog.staff_id)
+          sign_in @staff
+        end
+        context "削除されること、staff_blogs画面にリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "admin deletes blog and redirect to blogs page and returns a 200 response and does not redirect to root page" do
+            expect {
+              delete staff_blog_path @staff.id, @staff_blog.id
+            }.to change(@staff.blogs, :count).by(-1)
+            expect(response).to redirect_to staff_blogs_path
+            expect(response).to have_http_status "302"
+            expect(response).to_not redirect_to "/"
+          end
+        end
+      end
+    end
+
+    context "異常系" do
+      context "スタッフは管理者のブログにdeleteでアクセス" do
+        before do
+          @admin_blog = FactoryBot.create(:blog, :admin)
+          @admin = Staff.find(@admin_blog.staff_id)
+          staff = FactoryBot.create(:staff)
+          sign_in staff
+        end
+        context "削除されること、staff_blogs画面にリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "admin deletes blog and redirect to blogs page and returns a 200 response and does not redirect to root page" do
+            expect {
+              delete staff_blog_path @admin.id, @admin_blog.id
+            }.to_not change(@admin.blogs, :count)
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "スタッフは他のスタッフのブログにdeleteでアクセス" do
+        before do
+          @staff_blog = FactoryBot.create(:blog)
+          @staff = Staff.find(@staff_blog.staff_id)
+          login_staff = FactoryBot.create(:staff)
+          sign_in login_staff
+        end
+        context "削除されること、staff_blogs画面にリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "admin deletes blog and redirect to blogs page and returns a 200 response and does not redirect to root page" do
+            expect {
+              delete staff_blog_path @staff.id, @staff_blog.id
+            }.to_not change(@staff.blogs, :count)
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "セラピスト養成コースの受講生は管理者のブログにdeleteでアクセス" do
+        before do
+          @admin_blog = FactoryBot.create(:blog, :admin)
+          @admin = Staff.find(@admin_blog.staff_id)
+          student = FactoryBot.create(:student)
+          sign_in student
+        end
+        context "削除されること、staff_blogs画面にリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "admin deletes blog and redirect to blogs page and returns a 200 response and does not redirect to root page" do
+            expect {
+              delete staff_blog_path @admin.id, @admin_blog.id
+            }.to_not change(@admin.blogs, :count)
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "セラピスト養成コースの受講生はスタッフのブログにdeleteでアクセス" do
+        before do
+          @staff_blog = FactoryBot.create(:blog)
+          @staff = Staff.find(@staff_blog.staff_id)
+          student = FactoryBot.create(:student)
+          sign_in student
+        end
+        context "削除されること、staff_blogs画面にリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "admin deletes blog and redirect to blogs page and returns a 200 response and does not redirect to root page" do
+            expect {
+              delete staff_blog_path @staff.id, @staff_blog.id
+            }.to_not change(@staff.blogs, :count)
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "セルフケアコースの受講生は管理者のブログにdeleteでアクセス" do
+        before do
+          @admin_blog = FactoryBot.create(:blog, :admin)
+          @admin = Staff.find(@admin_blog.staff_id)
+          student = FactoryBot.create(:student, :self_care)
+          sign_in student
+        end
+        context "削除されること、staff_blogs画面にリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "admin deletes blog and redirect to blogs page and returns a 200 response and does not redirect to root page" do
+            expect {
+              delete staff_blog_path @admin.id, @admin_blog.id
+            }.to_not change(@admin.blogs, :count)
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "セルフケアコースの受講生はスタッフのブログにdeleteでアクセス" do
+        before do
+          @staff_blog = FactoryBot.create(:blog)
+          @staff = Staff.find(@staff_blog.staff_id)
+          student = FactoryBot.create(:student, :self_care)
+          sign_in student
+        end
+        context "削除されること、staff_blogs画面にリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "admin deletes blog and redirect to blogs page and returns a 200 response and does not redirect to root page" do
+            expect {
+              delete staff_blog_path @staff.id, @staff_blog.id
+            }.to_not change(@staff.blogs, :count)
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "ゲストは管理者のブログにdeleteでアクセス" do
+        before do
+          @admin_blog = FactoryBot.create(:blog, :admin)
+          @admin = Staff.find(@admin_blog.staff_id)
+        end
+        context "削除されること、staff_blogs画面にリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "admin deletes blog and redirect to blogs page and returns a 200 response and does not redirect to root page" do
+            expect {
+              delete staff_blog_path @admin.id, @admin_blog.id
+            }.to_not change(@admin.blogs, :count)
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+
+      context "ゲストはスタッフのブログにdeleteでアクセス" do
+        before do
+          @staff_blog = FactoryBot.create(:blog)
+          @staff = Staff.find(@staff_blog.staff_id)
+        end
+        context "削除されること、staff_blogs画面にリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+          it "admin deletes blog and redirect to blogs page and returns a 200 response and does not redirect to root page" do
+            expect {
+              delete staff_blog_path @staff.id, @staff_blog.id
+            }.to_not change(@staff.blogs, :count)
+            expect(response).not_to be_successful
+            expect(response).to have_http_status "302"
+            expect(response).to redirect_to "/"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/students_spec.rb
+++ b/spec/requests/students_spec.rb
@@ -1,0 +1,533 @@
+require 'rails_helper'
+
+RSpec.describe "Students", type: :request do
+  describe "#index" do
+    context "正常系" do
+      context "管理者としてログインしたとき" do
+        context "as admin" do
+          before do
+            admin = FactoryBot.create(:staff, :admin)
+            sign_in admin
+            get students_path
+          end
+          context "正常にレスポンスを返すこと" do
+            it "responds successfully" do
+              expect(response).to be_successful
+            end
+          end
+          context "200レスポンスを返すこと" do
+            it "returns a 200 response" do
+              expect(response).to have_http_status "200"
+            end
+          end
+        end
+        #context "ルート画面にリダイレクトされないこと" do
+        #  it "does not redirect to root page" do
+        #    expect(response).to_not redirect_to root_path
+        #  end
+        #end
+      end
+    end
+
+    context "異常系" do
+      context "スタッフとしてログインしたとき" do
+        context "as a staff" do
+          before do
+            staff = FactoryBot.create(:staff)
+            sign_in staff
+            get students_path
+          end
+          context "正常にレスポンスを返さないこと" do
+            it "responds not successfully" do
+              expect(response).not_to be_successful
+            end
+          end
+          context "302レスポンスを返すこと" do
+            it "returns a 302 response" do
+              expect(response).to have_http_status "302"
+            end
+          end
+          context "ルート画面にリダイレクトすること" do
+            it "redirects to root page" do
+              expect(response).to redirect_to "/"
+            end
+          end
+        end
+      end
+
+      context "セラピスト養成コースの受講生としてログインしたとき" do
+        context "as a therapist training course student" do
+          before do
+            student = FactoryBot.create(:student)
+            sign_in student
+            get students_path
+          end
+          context "正常にレスポンスを返さないこと" do
+            it "responds not successfully" do
+              expect(response).not_to be_successful
+            end
+          end
+          context "302レスポンスを返すこと" do
+            it "returns a 302 response" do
+              expect(response).to have_http_status "302"
+            end
+          end
+          context "ルート画面にリダイレクトすること" do
+            it "redirects to root page" do
+              expect(response).to redirect_to "/"
+            end
+          end
+        end
+      end
+
+      context "セルフケアコースの受講生としてログインしたとき" do
+        context "as a self care coure student" do
+          before do
+            student = FactoryBot.create(:student, :self_care)
+            sign_in student
+            get students_path
+          end
+          context "正常にレスポンスを返さないこと" do
+            it "responds not successfully" do
+              expect(response).not_to be_successful
+            end
+          end
+          context "302レスポンスを返すこと" do
+            it "returns a 302 response" do
+              expect(response).to have_http_status "302"
+            end
+          end
+          context "ルート画面にリダイレクトすること" do
+            it "redirects to root page" do
+              expect(response).to redirect_to root_path
+            end
+          end
+        end
+      end
+
+      context "ゲストとして" do
+        context "as a guest" do
+          before do
+            get students_path
+          end
+          context "正常にレスポンスを返さないこと" do
+            it "responds not successfully" do
+              expect(response).not_to be_successful
+            end
+          end
+          context "302レスポンスを返すこと" do
+            it "returns a 302 response" do
+              expect(response).to have_http_status "302"
+            end
+          end
+          context "ルート画面にリダイレクトすること" do
+            it "redirects to root page" do
+              expect(response).to redirect_to root_path
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe "#show" do
+    context "正常系" do
+      context "管理者としてログインしたとき" do
+        context "as admin" do
+          before do
+            admin = FactoryBot.create(:staff, :admin)
+            sign_in admin
+            student = FactoryBot.create(:student)
+            get student_path student.id
+          end
+          context "正常にレスポンスを返すこと" do
+            it "responds successfully" do
+              expect(response).to be_successful
+            end
+          end
+          context "200レスポンスを返すこと" do
+            it "returns a 200 response" do
+              expect(response).to have_http_status "200"
+            end
+          end
+          context "ルート画面にリダイレクトされないこと" do
+            it "does not redirect to root page" do
+              expect(response).to_not redirect_to "/"
+            end
+          end
+        end
+      end
+    end
+
+    context "異常系" do
+      context "スタッフとしてログインしたとき" do
+        context "as a staff" do
+          before do
+            staff = FactoryBot.create(:staff)
+            sign_in staff
+            student = FactoryBot.create(:student)
+            get student_path student.id
+          end
+          context "正常にレスポンスを返さないこと" do
+            it "responds not successfully" do
+              expect(response).not_to be_successful
+            end
+          end
+          context "302レスポンスを返すこと" do
+            it "returns a 302 response" do
+              expect(response).to have_http_status "302"
+            end
+          end
+          context "ルート画面にリダイレクトすること" do
+            it "redirects to root page" do
+              expect(response).to redirect_to "/"
+            end
+          end
+        end
+      end
+
+      context "セラピスト養成コースの受講生としてログインしたとき" do
+        context "as a therapist training course student" do
+          before do
+            login_student = FactoryBot.create(:student)
+            sign_in login_student
+            student = FactoryBot.create(:student)
+            get student_path student.id
+          end
+          context "正常にレスポンスを返さないこと" do
+            it "responds not successfully" do
+              expect(response).not_to be_successful
+            end
+          end
+          context "302レスポンスを返すこと" do
+            it "returns a 302 response" do
+              expect(response).to have_http_status "302"
+            end
+          end
+          context "ルート画面にリダイレクトすること" do
+            it "redirects to root page" do
+              expect(response).to redirect_to root_path
+            end
+          end
+        end
+      end
+
+      context "セルフケアコースの受講生としてログインしたとき" do
+        context "as a self care course student" do
+          before do
+            login_student = FactoryBot.create(:student, :self_care)
+            sign_in login_student
+            student = FactoryBot.create(:student)
+            get student_path student.id
+          end
+          context "正常にレスポンスを返さないこと" do
+            it "responds not successfully" do
+              expect(response).not_to be_successful
+            end
+          end
+          context "302レスポンスを返すこと" do
+            it "returns a 302 response" do
+              expect(response).to have_http_status "302"
+            end
+          end
+          context "ルート画面にリダイレクトすること" do
+            it "redirects to root page" do
+              expect(response).to redirect_to root_path
+            end
+          end
+        end
+      end
+
+      context "ゲストとして" do
+        context "as a guest" do
+          before do
+            student = FactoryBot.create(:student)
+            get student_path student.id
+          end
+          context "正常にレスポンスを返さないこと" do
+            it "responds not successfully" do
+              expect(response).not_to be_successful
+            end
+          end
+          context "302レスポンスを返すこと" do
+            it "returns a 302 response" do
+              expect(response).to have_http_status "302"
+            end
+          end
+          context "ルート画面にリダイレクトすること" do
+            it "redirects to root page" do
+              expect(response).to redirect_to root_path
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe "#update" do
+    context "正常系" do
+      context "管理者としてログインしたとき" do
+        context "as admin" do
+          before do
+            admin = FactoryBot.create(:staff, :admin)
+            sign_in admin
+            @student = FactoryBot.create(:student)
+            student_params = FactoryBot.attributes_for(:student, name: "abc")
+            patch student_path @student.id, params: { student: student_params }
+          end
+          context "abcに更新されること" do
+            it "updated to abc" do
+              expect(@student.reload.name).to eq "abc"
+            end
+          end
+          context "詳細ページへリダイレクトされること" do
+            it "redirets to " do
+              expect(response).to redirect_to student_path
+            end
+          end
+          context "302レスポンスを返すこと" do
+            it "returns a 302 response" do
+              expect(response).to have_http_status "302"
+            end
+          end
+          context "ルート画面にリダイレクトされないこと" do
+            it "does not redirect to root page" do
+              expect(response).to_not redirect_to "/"
+            end
+          end
+        end
+      end
+    end
+
+    context "異常系" do
+      context "スタッフとしてログインしたとき" do
+        context "as a staff" do
+          before do
+            staff = FactoryBot.create(:staff)
+            sign_in staff
+            @student = FactoryBot.create(:student)
+            student_params = FactoryBot.attributes_for(:student, name: "abc")
+            patch student_path @student.id, params: { student: student_params }
+          end
+          context "abcに更新されないこと" do
+            it "not updated to abc" do
+              expect(@student.reload.name).to_not eq "abc"
+            end
+          end
+          context "正常にレスポンスを返さないこと" do
+            it "responds not successfully" do
+              expect(response).to_not be_successful
+            end
+          end
+          context "302レスポンスを返すこと" do
+            it "returns a 302 response" do
+              expect(response).to have_http_status "302"
+            end
+          end
+          context "ルート画面にリダイレクトすること" do
+            it "redirects to root page" do
+              expect(response).to redirect_to "/"
+            end
+          end
+        end
+      end
+
+      context "セラピスト養成コースの受講生としてログインしたとき" do
+        context "as a therapist training course student" do
+          before do
+            login_student = FactoryBot.create(:student)
+            sign_in login_student
+            @student = FactoryBot.create(:student)
+            student_params = FactoryBot.attributes_for(:student, name: "abc")
+            patch student_path @student.id, params: { student: student_params }
+          end
+          context "abcに更新されないこと" do
+            it "not updated to abc" do
+              expect(@student.reload.name).to_not eq "abc"
+            end
+          end
+          context "正常にレスポンスを返さないこと" do
+            it "responds not successfully" do
+              expect(response).not_to be_successful
+            end
+          end
+          context "302レスポンスを返すこと" do
+            it "returns a 302 response" do
+              expect(response).to have_http_status "302"
+            end
+          end
+          context "ルート画面にリダイレクトすること" do
+            it "redirects to root page" do
+              expect(response).to redirect_to root_path
+            end
+          end
+        end
+      end
+
+      context "セルフケアコースの受講生としてログインしたとき" do
+        context "as a self care course student" do
+          before do
+            login_student = FactoryBot.create(:student, :self_care)
+            sign_in login_student
+            @student = FactoryBot.create(:student)
+            student_params = FactoryBot.attributes_for(:student, name: "abc")
+            patch student_path @student.id, params: { student: student_params }
+          end
+          context "abcに更新されないこと" do
+            it "not updated to abc" do
+              expect(@student.reload.name).to_not eq "abc"
+            end
+          end
+          context "正常にレスポンスを返さないこと" do
+            it "responds not successfully" do
+              expect(response).not_to be_successful
+            end
+          end
+          context "302レスポンスを返すこと" do
+            it "returns a 302 response" do
+              expect(response).to have_http_status "302"
+            end
+          end
+          context "ルート画面にリダイレクトすること" do
+            it "redirects to root page" do
+              expect(response).to redirect_to root_path
+            end
+          end
+        end
+      end
+
+      context "ゲストとして" do
+        context "as a guest" do
+          before do
+            @student = FactoryBot.create(:student)
+            student_params = FactoryBot.attributes_for(:student, name: "abc")
+            patch student_path @student.id, params: { student: student_params }
+          end
+          context "abcに更新されないこと" do
+            it "not updated to abc" do
+              expect(@student.reload.name).to_not eq "abc"
+            end
+          end
+          context "正常にレスポンスを返さないこと" do
+            it "responds not successfully" do
+              expect(response).not_to be_successful
+            end
+          end
+          context "302レスポンスを返すこと" do
+            it "returns a 302 response" do
+              expect(response).to have_http_status "302"
+            end
+          end
+          context "ルート画面にリダイレクトすること" do
+            it "redirects to root page" do
+              expect(response).to redirect_to root_path
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe "#destroy" do
+    context "正常系" do
+      context "管理者としてログインしたとき" do
+        context "as admin" do
+          before do
+            admin = FactoryBot.create(:staff, :admin)
+            sign_in admin
+            @student = FactoryBot.create(:student)
+          end
+          context "削除されること、students画面にリダイレクトされること、302レスポンスを返すこと、ルート画面にリダイレクトされないこと" do
+            it "admin deletes student and redirect to students page and returns a 200 response and does not redirect to root page" do
+              expect {
+                delete student_path @student.id
+              }.to change(Student, :count).by(-1)
+              #expect(response).to be_successful
+              expect(response).to redirect_to students_path
+              expect(response).to have_http_status "302"
+              expect(response).to_not redirect_to "/"
+            end
+          end
+        end
+      end
+    end
+    context "異常系" do
+      context "スタッフとしてログインしたとき" do
+        context "as a staff" do
+          before do
+            staff = FactoryBot.create(:staff)
+            sign_in staff
+            @student = FactoryBot.create(:student)
+          end
+          context "削除できないこと、正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+            it "does not delelt student and responds not successfully and returns a 302 response and redirects to root page" do
+              expect {
+                delete student_path @student.id
+              }.to_not change(Student, :count)
+              expect(response).not_to be_successful
+              expect(response).to have_http_status "302"
+              expect(response).to redirect_to "/"
+            end
+          end
+        end
+      end
+      context "セラピスト養成コースの受講生としてログインしたとき" do
+        context "as a therapist training course student" do
+          before do
+            login_student = FactoryBot.create(:student)
+            sign_in login_student
+            @student = FactoryBot.create(:student)
+          end
+          context "削除できないこと、正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+            it "does not delelt student and responds not successfully and returns a 302 response and redirects to root page" do
+              expect {
+                delete student_path @student.id
+              }.to_not change(Student, :count)
+              expect(response).not_to be_successful
+              expect(response).to have_http_status "302"
+              expect(response).to redirect_to "/"
+            end
+          end
+        end
+      end
+      context "セルフケアコースの受講生としてログインしたとき" do
+        context "as a self care coure student" do
+          before do
+            login_student = FactoryBot.create(:student, :self_care)
+            sign_in login_student
+            @student = FactoryBot.create(:student)
+          end
+          context "削除できないこと、正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+            it "does not delelt student and responds not successfully and returns a 302 response and redirects to root page" do
+              expect {
+                delete student_path @student.id
+              }.to_not change(Student, :count)
+              expect(response).not_to be_successful
+              expect(response).to have_http_status "302"
+              expect(response).to redirect_to "/"
+            end
+          end
+        end
+      end
+
+      context "ゲストとして" do
+        context "as a guest" do
+          before do
+            @student = FactoryBot.create(:student)
+          end
+          context "削除できないこと、正常にレスポンスを返さないこと、302レスポンスを返すこと、ルート画面にリダイレクトすること" do
+            it "does not delelt student and responds not successfully and returns a 302 response and redirects to root page" do
+              expect {
+                delete student_path @student.id
+              }.to_not change(Student, :count)
+              expect(response).not_to be_successful
+              expect(response).to have_http_status "302"
+              expect(response).to redirect_to "/"
+            end
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/spec/support/login_support.rb
+++ b/spec/support/login_support.rb
@@ -1,0 +1,14 @@
+module LoginSupport
+  def sign_in_as_admin
+    admin = FactoryBot.create(:staff, :admin)
+    sign_in admin
+    visit admin_screen_path
+    expect(page).to have_content "管理者画面"
+    click_link "受講生管理"
+    expect(page).to have_content "受講生一覧"
+  end
+end
+
+RSpec.configure do |config|
+  config.include LoginSupport
+end

--- a/spec/system/blogs_spec.rb
+++ b/spec/system/blogs_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe "Blogs", type: :system do
             expect(page).to have_content "title0"
             expect(page).to have_content I18n.l(Date.today, format: :longdate)
           }.to change(admin.blogs, :count).by(1)
+          click_link "戻る"
+          expect(page).to have_content "管理者"
         end
       end
 
@@ -49,8 +51,10 @@ RSpec.describe "Blogs", type: :system do
             expect(page).to have_content "スタッフブログ詳細表示"
             expect(page).to have_content "title0"
             expect(page).to have_content I18n.l(Date.today, format: :longdate)
-            #expect(page).to have_selector("img[src$='default.jpg']")
            }.to change(admin.blogs, :count).by(1)
+          click_link "戻る"
+          expect(page).to have_selector("img[src$='default.jpg']")
+          expect(page).to have_content "管理者"
         end
       end
 
@@ -77,8 +81,8 @@ RSpec.describe "Blogs", type: :system do
 
       context "スタッフは新しいブログを作成する" do 
         it "a staff creates new blog" do
-          staff = FactoryBot.create(:staff)
-          fill_in "Eメール", with: staff.email
+          @staff = FactoryBot.create(:staff)
+          fill_in "Eメール", with: @staff.email
           click_button 'ログイン'
           click_link "スタッフブログ投稿"
           expect(page).to have_content "スタッフブログ一覧"
@@ -92,14 +96,16 @@ RSpec.describe "Blogs", type: :system do
             expect(page).to have_content "スタッフブログ詳細表示"
             expect(page).to have_content "title1"
             expect(page).to have_content I18n.l(Date.today, format: :longdate)
-          }.to change(staff.blogs, :count).by(1)
+          }.to change(@staff.blogs, :count).by(1)
+          click_link "戻る"
+          expect(page).to have_content @staff.name
         end
       end
 
       context "スタッフは画像の無い新しいブログを作成する" do
         it "staff creates new blog without picture" do
-          staff = FactoryBot.create(:staff)
-          fill_in "Eメール", with: staff.email
+          @staff = FactoryBot.create(:staff)
+          fill_in "Eメール", with: @staff.email
           click_button 'ログイン'
           click_link "スタッフブログ投稿"
           expect(page).to have_content "スタッフブログ一覧"
@@ -113,8 +119,10 @@ RSpec.describe "Blogs", type: :system do
             expect(page).to have_content "スタッフブログ詳細表示"
             expect(page).to have_content "title1"
             expect(page).to have_content I18n.l(Date.today, format: :longdate)
-            #expect(page).to have_selector("img[src$='default.jpg']")
-          }.to change(staff.blogs, :count).by(1)
+          }.to change(@staff.blogs, :count).by(1)
+          click_link "戻る"
+          expect(page).to have_selector("img[src$='default.jpg']")
+          expect(page).to have_content @staff.name
         end
       end
 

--- a/spec/system/routes_spec.rb
+++ b/spec/system/routes_spec.rb
@@ -16,14 +16,14 @@ RSpec.describe "Routes", type: :system do
       click_button 'ログイン'
       expect(page).to have_content "ログインしました。"
       expect(page).to have_content "管理者画面"
-      expect(page).to have_content "スタッフブログ投稿"
-      expect(page).to have_content "開講スケジュール投稿"
-      expect(page).to have_content "受講生管理"
+      expect(page).to have_link "スタッフブログ投稿"
+      expect(page).to have_link "開講スケジュール投稿"
+      expect(page).to have_link "受講生管理"
       visit root_path
       expect(page).to have_content "管理者画面"
-      expect(page).to have_content "スタッフブログ投稿"
-      expect(page).to have_content "開講スケジュール投稿"
-      expect(page).to have_content "受講生管理"
+      expect(page).to have_link "スタッフブログ投稿"
+      expect(page).to have_link "開講スケジュール投稿"
+      expect(page).to have_link "受講生管理"
     end
   end
 
@@ -35,12 +35,12 @@ RSpec.describe "Routes", type: :system do
       click_button 'ログイン'
       expect(page).to have_content "ログインしました。"
       expect(page).to have_content "スタッフ画面"
-      expect(page).to have_content "スタッフブログ投稿"
-      expect(page).to have_content "開講スケジュール投稿"
+      expect(page).to have_link "スタッフブログ投稿"
+      expect(page).to have_link "開講スケジュール投稿"
       visit root_path
       expect(page).to have_content "スタッフ画面"
-      expect(page).to have_content "スタッフブログ投稿"
-      expect(page).to have_content "開講スケジュール投稿"
+      expect(page).to have_link "スタッフブログ投稿"
+      expect(page).to have_link "開講スケジュール投稿"
     end
   end
 

--- a/spec/system/routes_spec.rb
+++ b/spec/system/routes_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe "Routes", type: :system do
+  before do
+    @admin = FactoryBot.create(:staff, :admin)
+    @staff = FactoryBot.create(:staff)
+    @therapist_training = FactoryBot.create(:student)
+    @self_care = FactoryBot.create(:student, :self_care)
+  end
+
+  describe "管理者としてログインして、ルートにアクセス" do
+    it "redirect to admin screen" do
+      visit root_path
+      click_link "管理者・スタッフはこちら"
+      fill_in "Eメール", with: @admin.email
+      click_button 'ログイン'
+      expect(page).to have_content "ログインしました。"
+      expect(page).to have_content "管理者画面"
+      expect(page).to have_content "スタッフブログ投稿"
+      expect(page).to have_content "開講スケジュール投稿"
+      expect(page).to have_content "受講生管理"
+      visit root_path
+      expect(page).to have_content "管理者画面"
+      expect(page).to have_content "スタッフブログ投稿"
+      expect(page).to have_content "開講スケジュール投稿"
+      expect(page).to have_content "受講生管理"
+    end
+  end
+
+  describe "スタッフとしてログインして、ルートにアクセス" do
+    it "redirect to staff screen" do
+      visit root_path
+      click_link "管理者・スタッフはこちら"
+      fill_in "Eメール", with: @staff.email
+      click_button 'ログイン'
+      expect(page).to have_content "ログインしました。"
+      expect(page).to have_content "スタッフ画面"
+      expect(page).to have_content "スタッフブログ投稿"
+      expect(page).to have_content "開講スケジュール投稿"
+      visit root_path
+      expect(page).to have_content "スタッフ画面"
+      expect(page).to have_content "スタッフブログ投稿"
+      expect(page).to have_content "開講スケジュール投稿"
+    end
+  end
+
+  describe "セラピスト養成コースの受講生としてログインして、ルートにアクセス" do
+    it "redirect to therapist_training screen" do
+      visit root_path
+      fill_in "Eメール", with: @therapist_training.email
+      click_button 'ログイン'
+      expect(page).to have_content "ログインしました。"
+      expect(page).to have_content "セラピスト養成コース"
+      visit root_path
+      expect(page).to have_content "セラピスト養成コース"
+    end
+  end
+
+  describe "セルフケアコースの受講生としてログインして、ルートにアクセス" do
+    it "redirect to self_care screen" do
+      visit root_path
+      fill_in "Eメール", with: @self_care.email
+      click_button 'ログイン'
+      expect(page).to have_content "ログインしました。"
+      expect(page).to have_content "セルフケアコース"
+      visit root_path
+      expect(page).to have_content "セルフケアコース"
+    end
+  end
+
+  describe "ゲストがスタッフブログを見ているとき、ルートにアクセス" do
+    it "redirect to students/sessions#new" do
+      visit root_path
+      click_link "スタッフブログはこちら（一般向け）,（仮）"
+      expect(page).to have_content "スタッフブログ一覧"
+      visit root_path
+      expect(page).to have_content "ログイン"
+      expect(page).to have_content "Eメール"
+      expect(page).to have_content "ログインを記憶する"
+      expect(page).to have_content "管理者・スタッフはこちら"
+      expect(page).to have_content "スタッフブログはこちら（一般向け）,（仮）"
+    end
+  end
+end

--- a/spec/system/routes_spec.rb
+++ b/spec/system/routes_spec.rb
@@ -77,8 +77,9 @@ RSpec.describe "Routes", type: :system do
       expect(page).to have_content "ログイン"
       expect(page).to have_content "Eメール"
       expect(page).to have_content "ログインを記憶する"
-      expect(page).to have_content "管理者・スタッフはこちら"
-      expect(page).to have_content "スタッフブログはこちら（一般向け）,（仮）"
+      expect(page).to have_button "ログイン"
+      expect(page).to have_link "管理者・スタッフはこちら"
+      expect(page).to have_link "スタッフブログはこちら（一般向け）,（仮）"
     end
   end
 end

--- a/spec/system/students_spec.rb
+++ b/spec/system/students_spec.rb
@@ -12,12 +12,13 @@ RSpec.describe "Students", type: :system do
       1.upto 10 do |n|
         @self_care[n] = FactoryBot.create(:student, :self_care_system_student)
       end
-      admin = FactoryBot.create(:staff, :admin)
-      sign_in admin
-      visit admin_screen_path
-      expect(page).to have_content "管理者画面"
-      click_link "受講生管理"
-      expect(page).to have_content "受講生一覧"
+      sign_in_as_admin
+      #admin = FactoryBot.create(:staff, :admin)
+      #sign_in admin
+      #visit admin_screen_path
+      #expect(page).to have_content "管理者画面"
+      #click_link "受講生管理"
+      #expect(page).to have_content "受講生一覧"
     end
 
     describe "一覧表示機能" do
@@ -317,17 +318,12 @@ RSpec.describe "Students", type: :system do
   end
 
   describe "CSVファイルインポート機能" do
-    before do
-      admin = FactoryBot.create(:staff, :admin)
-      sign_in admin
-      visit admin_screen_path
-      expect(page).to have_content "管理者画面"
-      click_link "受講生管理"
-      expect(page).to have_content "受講生一覧"
-    end
     context "正常系" do
       context "管理者はCSVファイルをインポートする" do
         context "元からstudentが登録されていないとき" do
+          before do
+            sign_in_as_admin
+          end
           it "admin imports CSV file" do
             attach_file "file", "/mnt/c/Users/ruffini47/Documents/セレブエンジニア/人工インターン_EarTherage/売上データ4.csv"
             click_button "CSVをインポート"
@@ -363,6 +359,7 @@ RSpec.describe "Students", type: :system do
             5.times do
               FactoryBot.create(:student, :sample)
             end
+            sign_in_as_admin
           end
           it "admin imports CSV file" do
             attach_file "file", "/mnt/c/Users/ruffini47/Documents/セレブエンジニア/人工インターン_EarTherage/売上データ4.csv"
@@ -399,6 +396,7 @@ RSpec.describe "Students", type: :system do
             10.times do
               FactoryBot.create(:student, :sample)
             end
+            sign_in_as_admin
           end
           it "admin imports CSV file" do
             attach_file "file", "/mnt/c/Users/ruffini47/Documents/セレブエンジニア/人工インターン_EarTherage/売上データ4.csv"
@@ -434,6 +432,9 @@ RSpec.describe "Students", type: :system do
     end
     context "異常系" do
       context "管理者はCSVファイルを選択しないでCSVをインポートボタンを押す" do
+        before do
+          sign_in_as_admin
+        end
         it "admin presses CSV import button without selecting CSV file" do
           click_button "CSVをインポート"
           expect(page).to have_content "csvデータが選択されていません。"


### PR DESCRIPTION
・やったこと
 　RSpecの追加の他、ログイン状態でrootに来たら、ログイン後に遷移されるページに自動的にリダイレクトするようにするよう実装をしました。
・動作確認
　セラピスト養成コース、セルフケアコース、スタッフ、管理者でそれぞれログイン時、rootにアクセスすると、それぞれのログイン後のページに自動的にリダイレクトされます。未ログイン時、rootにアクセスすると、"students/sessions#new"にリダイレクトされます。
bin/rspecコマンドで確認しました。